### PR TITLE
feat: update patcher dependencies and refresh scheduling

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -5,7 +5,8 @@ name: Refresh Bundles & Patches
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/30 * * * *'
+    # Avoid the start of the hour, when GitHub Actions scheduled runs are most likely to be delayed or dropped.
+    - cron: '17,47 * * * *'
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+local.properties
 
 ### Kotlin ###
 .kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,6 +99,10 @@ tasks.test {
 }
 kotlin {
     jvmToolchain(21)
+
+    compilerOptions {
+        freeCompilerArgs.add("-Xskip-prerelease-check")
+    }
 }
 
 application {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.2.21"
+kotlin = "2.4.10"
 ktor = "3.2.3"
 exposed = "1.0.0-rc-4"
 hikari = "5.1.0"
@@ -7,8 +7,8 @@ postgresql = "42.7.3"
 koin = "3.5.3"
 openapi-tools = "5.4.0"
 dotenv = "6.5.1"
-revanced-patcher = "21.1.0-dev.5"
-morphe-patcher = "1.3.3"
+revanced-patcher = "22.1.0-dev.1"
+morphe-patcher = "1.11.0"
 logback = "1.5.24"
 apksig = "8.1.1"
 
@@ -48,7 +48,7 @@ postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" 
 
 # Other
 dotenv = { module = "io.github.cdimascio:dotenv-kotlin", version.ref = "dotenv" }
-revanced-patcher = { module = "app.revanced:revanced-patcher", version.ref = "revanced-patcher" }
+revanced-patcher = { module = "app.revanced:patcher-jvm", version.ref = "revanced-patcher" }
 morphe-patcher = { module = "app.morphe:morphe-patcher", version.ref = "morphe-patcher" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 apksig = { module = "com.android.tools.build:apksig", version.ref = "apksig" }

--- a/src/main/kotlin/me/brosssh/bundles/domain/models/Bundle.kt
+++ b/src/main/kotlin/me/brosssh/bundles/domain/models/Bundle.kt
@@ -6,7 +6,7 @@ import org.koin.core.component.inject
 import java.io.File
 import java.util.*
 import app.morphe.patcher.patch.loadPatchesFromJar as loadMorpheBundle
-import app.revanced.patcher.patch.loadPatchesFromJar as loadReVancedBundle
+import app.revanced.patcher.patch.loadPatches as loadReVancedBundle
 
 sealed class Bundle(
     val version: String,
@@ -132,7 +132,10 @@ class ReVancedV4Bundle(
     override val bundleType = BundleType.REVANCED_V4
 
     override suspend fun loadPatchesFromBundle(bundleFile: File) =
-        loadReVancedBundle(setOf(bundleFile))
+        loadReVancedBundle(
+            bundleFile,
+            onFailedToLoad = { _, throwable -> throw throwable }
+        )
             .map { ReVancedPatchAdapter(it) }
             .toSet()
 }

--- a/src/main/kotlin/me/brosssh/bundles/domain/models/Patch.kt
+++ b/src/main/kotlin/me/brosssh/bundles/domain/models/Patch.kt
@@ -11,7 +11,7 @@ interface Patch {
 }
 
 class ReVancedPatchAdapter(
-    val patch: ReVancedPatch<*>
+    val patch: ReVancedPatch
 ) : Patch {
     override val name get() = patch.name
     override val description get() = patch.description


### PR DESCRIPTION
## Summary

Updates the ReVanced and Morphe patcher dependencies and adjusts the scheduled bundle refresh workflow to improve refresh consistency. Closes https://github.com/brosssh/revanced-external-bundles/issues/33 and (hopefully) https://github.com/brosssh/revanced-external-bundles/issues/32.

## Changes

* Update ReVanced Patcher from `21.1.0-dev.5` to `22.1.0-dev.1`.
* Update the ReVanced dependency from `app.revanced:revanced-patcher` to the new `app.revanced:patcher-jvm` artifact.
* Update Morphe Patcher from `1.3.3` to `1.11.0`.
* Update Kotlin from `2.2.21` to `2.4.10` for compatibility with the updated Morphe Patcher.
* Add `-Xskip-prerelease-check` for compatibility with the selected ReVanced development release.
* Update ReVanced patch loading for the v22 API.
* Preserve fail-fast behavior when a ReVanced bundle fails to load, preventing a failed load from being treated as an empty patch set.
* Move the scheduled refresh times from `:00`/`:30` to `:17`/`:47` while maintaining the existing 30-minute interval.
* Add `local.properties` to `.gitignore` so I could test my changes locally.

## Refresh Scheduling

The scheduled refresh adjustment is based on GitHub's official GitHub Actions documentation.

GitHub documents that scheduled workflow events may be delayed during periods of high Actions load, that the start of every hour is considered a high-load period, and that sufficiently high load can result in queued jobs being dropped. GitHub recommends scheduling workflows at a different minute within the hour to reduce the chance of delays.

For that reason, the schedule was changed from:

```yaml
- cron: '*/30 * * * *'
```

to:

```yaml
- cron: '17,47 * * * *'
```

This retains a 30-minute interval while avoiding the start of the hour.

GitHub documentation:
https://docs.github.com/en/actions/how-tos/troubleshoot-workflows#scheduled-workflows-running-at-unexpected-times

This is intended as a mitigation for GitHub Actions scheduling delays and is not a guarantee that scheduled workflows will always start at their exact configured time.

## Testing

* `./gradlew clean build --no-daemon` passes successfully using JDK 21.
* `actionlint` passes for the modified refresh workflow.
* `git diff --check` passes.