### PR TITLE
fix: update container retention action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           subject-path: build/libs/revanced-external-bundles-*.jar
 
       - name: Purge outdated images
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.gradle
+.gradle**
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/


### PR DESCRIPTION
## Summary

Updates `snok/container-retention-policy` from `v3.0.1` to `v3.1.0` in the release workflow.

The previous version rejects newer valid GitHub Actions/GitHub App installation token formats, causing the `Purge outdated images` step to fail even though the preceding release steps complete successfully.

`v3.1.0` updates the token parsing logic to support the newer token format.

## Changes

* Updated `snok/container-retention-policy` from `v3.0.1` to `v3.1.0`
* Kept `token: ${{ secrets.GITHUB_TOKEN }}` unchanged
* Includes the existing `.gitignore` adjustment from `.gradle` to `.gradle**`

## Validation

* Verified the workflow with `actionlint`
* Ran `git diff --check`
* Confirmed the `Purge outdated images` configuration remains otherwise unchanged
* Successfully built the application Docker image locally as a validation check
* Confirmed the resulting image contains the expected `app.jar`