### PR TITLE
fix(sources): hide data from disabled sources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,8 @@ dependencies {
     implementation(libs.semver4j)
 
     testImplementation(libs.kotlin.test)
+    testImplementation(libs.ktor.test.host)
+    testRuntimeOnly(libs.h2)
 }
 
 tasks.test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ ktor = "3.2.3"
 exposed = "1.0.0-rc-4"
 hikari = "5.1.0"
 postgresql = "42.7.3"
+h2 = "2.3.232"
 koin = "3.5.3"
 openapi-tools = "5.4.0"
 dotenv = "6.5.1"
@@ -20,6 +21,7 @@ ktor-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation-j
 ktor-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json-jvm", version.ref = "ktor" }
 ktor-call-logging = { module = "io.ktor:ktor-server-call-logging-jvm", version.ref = "ktor" }
 ktor-auth = { module = "io.ktor:ktor-server-auth-jvm", version.ref = "ktor" }
+ktor-test-host = { module = "io.ktor:ktor-server-test-host-jvm", version.ref = "ktor" }
 
 # Ktor client
 ktor-client-core = { module = "io.ktor:ktor-client-core-jvm", version.ref = "ktor" }
@@ -45,6 +47,7 @@ exposed-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetime", v
 # Hikari & Postgres
 hikari-cp = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
+h2 = { module = "com.h2database:h2", version.ref = "h2" }
 
 # Other
 dotenv = { module = "io.github.cdimascio:dotenv-kotlin", version.ref = "dotenv" }

--- a/src/main/kotlin/me/brosssh/bundles/Application.kt
+++ b/src/main/kotlin/me/brosssh/bundles/Application.kt
@@ -8,6 +8,7 @@ import io.ktor.server.netty.*
 import io.ktor.server.routing.*
 import io.ktor.server.routing.IgnoreTrailingSlash
 import me.brosssh.bundles.api.v3.routes.bundleRoutes as bundleRoutesV3
+import me.brosssh.bundles.api.v3.routes.sourceRoutes
 import me.brosssh.bundles.api.routes.graphQLRoute
 import me.brosssh.bundles.api.v1.routes.bundleRoutes as bundleRoutesV1
 import me.brosssh.bundles.api.v1.routes.refreshRoutes
@@ -15,6 +16,7 @@ import me.brosssh.bundles.api.v2.routes.bundleRoutes as bundleRoutesV2
 import me.brosssh.bundles.db.SourceManifestSync
 import me.brosssh.bundles.db.migration.applyHasuraMetadata
 import me.brosssh.bundles.db.migration.migrationScript
+import me.brosssh.bundles.domain.services.SourceService
 import me.brosssh.bundles.plugins.*
 import org.koin.ktor.ext.inject
 
@@ -42,6 +44,7 @@ suspend fun Application.module() {
     migrationScript()
 
     val sourceManifestSync by inject<SourceManifestSync>()
+    val sourceService by inject<SourceService>()
     log.info(sourceManifestSync.sync().summary)
 
     applyHasuraMetadata()
@@ -65,6 +68,7 @@ suspend fun Application.module() {
 
         apiV3 {
             bundleRoutesV3()
+            sourceRoutes(Config.hasuraSecret, sourceService::hardDelete)
         }
 
         graphQLRoute()

--- a/src/main/kotlin/me/brosssh/bundles/api/v3/dto/SourceDeletionResponseDto.kt
+++ b/src/main/kotlin/me/brosssh/bundles/api/v3/dto/SourceDeletionResponseDto.kt
@@ -1,0 +1,21 @@
+package me.brosssh.bundles.api.v3.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import me.brosssh.bundles.domain.models.SourceDeletionResult
+
+@Serializable
+data class SourceDeletionResponseDto(
+    @SerialName("deleted_sources")
+    val deletedSources: Int,
+    @SerialName("deleted_bundles")
+    val deletedBundles: Int,
+    @SerialName("deleted_patches")
+    val deletedPatches: Int
+)
+
+fun SourceDeletionResult.Deleted.toResponseDto() = SourceDeletionResponseDto(
+    deletedSources = sources,
+    deletedBundles = bundles,
+    deletedPatches = patches
+)

--- a/src/main/kotlin/me/brosssh/bundles/api/v3/routes/SourceRoutes.kt
+++ b/src/main/kotlin/me/brosssh/bundles/api/v3/routes/SourceRoutes.kt
@@ -1,0 +1,110 @@
+package me.brosssh.bundles.api.v3.routes
+
+import io.github.smiley4.ktoropenapi.delete
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.header
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.route
+import me.brosssh.bundles.api.v3.dto.SourceDeletionResponseDto
+import me.brosssh.bundles.api.v3.dto.toResponseDto
+import me.brosssh.bundles.domain.models.SourceDeletionResult
+import me.brosssh.bundles.integrations.common.parseRepoUrl
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+internal const val HASURA_ADMIN_SECRET_HEADER = "X-Hasura-Admin-Secret"
+
+internal fun matchesAdminSecret(provided: String?, expected: String): Boolean =
+    provided != null &&
+            expected.isNotEmpty() &&
+            MessageDigest.isEqual(
+                provided.toByteArray(StandardCharsets.UTF_8),
+                expected.toByteArray(StandardCharsets.UTF_8)
+            )
+
+fun Route.sourceRoutes(
+    hasuraAdminSecret: String,
+    hardDeleteSource: (String) -> SourceDeletionResult
+) {
+    route("/source") {
+        delete("", {
+            summary = "Hard-delete a disabled source"
+            description = "Deletes a disabled source and its cached bundles and patches. " +
+                    "Requires the configured Hasura admin secret."
+            tags = listOf("Source v3")
+
+            request {
+                queryParameter<String>("source_url") {
+                    description = "Canonical URL of the disabled source"
+                    required = true
+                }
+                headerParameter<String>(HASURA_ADMIN_SECRET_HEADER) {
+                    description = "Hasura admin secret"
+                    required = true
+                }
+            }
+
+            response {
+                HttpStatusCode.OK to {
+                    description = "Source and cached data deleted"
+                    body<SourceDeletionResponseDto>()
+                }
+                HttpStatusCode.BadRequest to {
+                    description = "Invalid or missing source URL"
+                    body<Map<String, String>>()
+                }
+                HttpStatusCode.Unauthorized to {
+                    description = "Missing or invalid admin secret"
+                    body<Map<String, String>>()
+                }
+                HttpStatusCode.NotFound to {
+                    description = "Source not found"
+                    body<Map<String, String>>()
+                }
+                HttpStatusCode.Conflict to {
+                    description = "Source is still enabled"
+                    body<Map<String, String>>()
+                }
+            }
+        }) {
+            if (!matchesAdminSecret(call.request.header(HASURA_ADMIN_SECRET_HEADER), hasuraAdminSecret)) {
+                return@delete call.respond(
+                    HttpStatusCode.Unauthorized,
+                    mapOf("error" to "Missing or invalid admin secret.")
+                )
+            }
+
+            val sourceUrl = call.request.queryParameters["source_url"]
+                ?: return@delete call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf("error" to "Missing 'source_url' query parameter.")
+                )
+            val source = try {
+                parseRepoUrl(sourceUrl)
+            } catch (error: IllegalArgumentException) {
+                return@delete call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf("error" to (error.message ?: "Invalid 'source_url' query parameter."))
+                )
+            }
+
+            when (val result = hardDeleteSource(source.canonicalUrl)) {
+                SourceDeletionResult.NotFound -> call.respond(
+                    HttpStatusCode.NotFound,
+                    mapOf("error" to "Source not found.")
+                )
+
+                SourceDeletionResult.Enabled -> call.respond(
+                    HttpStatusCode.Conflict,
+                    mapOf("error" to "Source must be disabled before hard deletion.")
+                )
+
+                is SourceDeletionResult.Deleted -> call.respond(
+                    HttpStatusCode.OK,
+                    result.toResponseDto()
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/me/brosssh/bundles/di/AppModule.kt
+++ b/src/main/kotlin/me/brosssh/bundles/di/AppModule.kt
@@ -6,6 +6,7 @@ import me.brosssh.bundles.Config
 import me.brosssh.bundles.db.SourceManifestSync
 import me.brosssh.bundles.domain.services.BundleService
 import me.brosssh.bundles.domain.services.RefreshJobStatusService
+import me.brosssh.bundles.domain.services.SourceService
 import me.brosssh.bundles.domain.services.jobs.RefreshAllJobService
 import me.brosssh.bundles.domain.services.jobs.RefreshBundlesJobService
 import me.brosssh.bundles.domain.services.jobs.RefreshPatchesJobService
@@ -92,6 +93,7 @@ val appModule = module {
     }
 
     single { BundleService(get()) }
+    single { SourceService(get()) }
     single { RefreshJobStatusService(get()) }
     single { SourceManifestSync(get()) }
 

--- a/src/main/kotlin/me/brosssh/bundles/di/HttpClient.kt
+++ b/src/main/kotlin/me/brosssh/bundles/di/HttpClient.kt
@@ -32,7 +32,8 @@ val httpClientModule = module {
                 level = LogLevel.INFO
                 sanitizeHeader { header ->
                     header.equals(HttpHeaders.Authorization, ignoreCase = true) ||
-                        header.equals("PRIVATE-TOKEN", ignoreCase = true)
+                        header.equals("PRIVATE-TOKEN", ignoreCase = true) ||
+                        header.equals("X-Hasura-Admin-Secret", ignoreCase = true)
                 }
             }
         }

--- a/src/main/kotlin/me/brosssh/bundles/domain/models/SourceDeletionResult.kt
+++ b/src/main/kotlin/me/brosssh/bundles/domain/models/SourceDeletionResult.kt
@@ -1,0 +1,13 @@
+package me.brosssh.bundles.domain.models
+
+sealed interface SourceDeletionResult {
+    data object NotFound : SourceDeletionResult
+
+    data object Enabled : SourceDeletionResult
+
+    data class Deleted(
+        val sources: Int,
+        val bundles: Int,
+        val patches: Int
+    ) : SourceDeletionResult
+}

--- a/src/main/kotlin/me/brosssh/bundles/domain/services/SourceService.kt
+++ b/src/main/kotlin/me/brosssh/bundles/domain/services/SourceService.kt
@@ -1,0 +1,9 @@
+package me.brosssh.bundles.domain.services
+
+import me.brosssh.bundles.repositories.SourceRepository
+
+class SourceService(
+    private val sourceRepository: SourceRepository
+) {
+    fun hardDelete(sourceUrl: String) = sourceRepository.hardDelete(sourceUrl)
+}

--- a/src/main/kotlin/me/brosssh/bundles/repositories/BundleRepository.kt
+++ b/src/main/kotlin/me/brosssh/bundles/repositories/BundleRepository.kt
@@ -23,9 +23,11 @@ data class BundlePatchCandidate(
 
 class BundleRepository {
     fun findById(bundleId: Int) = transaction {
-        BundleTable
+        (BundleTable innerJoin SourceTable)
             .selectAll()
-            .where { BundleTable.id eq bundleId }
+            .where {
+                (BundleTable.id eq bundleId) and enabledSourceFilter
+            }
             .limit(1)
             .map(::rowToDomain)
             .singleOrNull()
@@ -77,9 +79,11 @@ class BundleRepository {
     }
 
     fun getBundlesNeedPatchesUpdate() = transaction {
-        BundleTable
+        (BundleTable innerJoin SourceTable)
             .selectAll()
-            .where { BundleTable.needPatchesUpdate eq true }
+            .where {
+                (BundleTable.needPatchesUpdate eq true) and enabledSourceFilter
+            }
             .map { row ->
                 BundlePatchCandidate(
                     id = row[BundleTable.id].value,
@@ -132,7 +136,8 @@ class BundleRepository {
         (BundleTable innerJoin SourceTable innerJoin SourceMetadataTable)
             .selectAll()
             .where {
-                (SourceMetadataTable.ownerName eq owner) and
+                enabledSourceFilter and
+                        (SourceMetadataTable.ownerName eq owner) and
                         (SourceMetadataTable.repoName eq repo) and
                         (BundleTable.isPrerelease eq prerelease) and
                         (BundleTable.isLatest eq true)
@@ -146,7 +151,8 @@ class BundleRepository {
         (BundleTable innerJoin SourceTable innerJoin SourceMetadataTable)
             .selectAll()
             .where {
-                (SourceMetadataTable.ownerName eq owner) and
+                enabledSourceFilter and
+                        (SourceMetadataTable.ownerName eq owner) and
                         (SourceMetadataTable.repoName eq repo) and
                         (BundleTable.version eq version)
             }
@@ -159,7 +165,8 @@ class BundleRepository {
         (BundleTable innerJoin SourceTable innerJoin SourceMetadataTable)
             .selectAll()
             .where {
-                (SourceMetadataTable.ownerName eq owner) and
+                enabledSourceFilter and
+                        (SourceMetadataTable.ownerName eq owner) and
                         (SourceMetadataTable.repoName eq repo) and
                         (BundleTable.isLatest eq true) and
                         channel.releaseFilter
@@ -201,6 +208,10 @@ class BundleRepository {
             .map(::rowToDomain)
             .singleOrNull()
     }
+
+    // v1 and v2 expose only bundles from enabled sources; explicit v3 lookups do not use this filter.
+    private val enabledSourceFilter: Op<Boolean>
+        get() = SourceTable.enabled eq true
 
     private fun sourceUrlFilter(sourceUrl: String) =
         (SourceTable.url eq sourceUrl) or (SourceTable.url eq "$sourceUrl/")

--- a/src/main/kotlin/me/brosssh/bundles/repositories/SourceRepository.kt
+++ b/src/main/kotlin/me/brosssh/bundles/repositories/SourceRepository.kt
@@ -1,12 +1,60 @@
 package me.brosssh.bundles.repositories
 
 import me.brosssh.bundles.db.entities.SourceEntity
+import me.brosssh.bundles.db.tables.BundleTable
+import me.brosssh.bundles.db.tables.PatchTable
+import me.brosssh.bundles.db.tables.SourceMetadataTable
 import me.brosssh.bundles.db.tables.SourceTable
+import me.brosssh.bundles.domain.models.SourceDeletionResult
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 class SourceRepository {
     fun getEnabled(): List<SourceEntity> = transaction {
         SourceEntity.find { SourceTable.enabled eq true }.toList()
+    }
+
+    fun hardDelete(sourceUrl: String): SourceDeletionResult = transaction {
+        val sourceRows = SourceTable
+            .selectAll()
+            .where {
+                (SourceTable.url eq sourceUrl) or (SourceTable.url eq "$sourceUrl/")
+            }
+            .forUpdate()
+            .toList()
+
+        if (sourceRows.isEmpty()) return@transaction SourceDeletionResult.NotFound
+        if (sourceRows.any { it[SourceTable.enabled] }) {
+            return@transaction SourceDeletionResult.Enabled
+        }
+
+        val sourceIds = sourceRows.map { it[SourceTable.id] }
+        val bundleIds = BundleTable
+            .selectAll()
+            .where { BundleTable.sourceFk inList sourceIds }
+            .map { it[BundleTable.id] }
+        val patchCount = if (bundleIds.isEmpty()) {
+            0
+        } else {
+            PatchTable
+                .selectAll()
+                .where { PatchTable.bundleFk inList bundleIds }
+                .count()
+                .toInt()
+        }
+
+        SourceMetadataTable.deleteWhere { SourceMetadataTable.sourceFk inList sourceIds }
+        val bundleCount = BundleTable.deleteWhere { BundleTable.sourceFk inList sourceIds }
+        val sourceCount = SourceTable.deleteWhere { SourceTable.id inList sourceIds }
+
+        SourceDeletionResult.Deleted(
+            sources = sourceCount,
+            bundles = bundleCount,
+            patches = patchCount
+        )
     }
 }

--- a/src/main/resources/hasura/metadata.json
+++ b/src/main/resources/hasura/metadata.json
@@ -52,7 +52,13 @@
                     "source_fk",
                     "description"
                   ],
-                  "filter": {},
+                  "filter": {
+                    "source": {
+                      "enabled": {
+                        "_eq": true
+                      }
+                    }
+                  },
                   "allow_aggregations": true
                 },
                 "comment": ""
@@ -131,7 +137,15 @@
                     "id",
                     "description"
                   ],
-                  "filter": {},
+                  "filter": {
+                    "bundle": {
+                      "source": {
+                        "enabled": {
+                          "_eq": true
+                        }
+                      }
+                    }
+                  },
                   "allow_aggregations": true
                 },
                 "comment": ""
@@ -165,7 +179,17 @@
                     "package_fk",
                     "patch_fk"
                   ],
-                  "filter": {},
+                  "filter": {
+                    "patch": {
+                      "bundle": {
+                        "source": {
+                          "enabled": {
+                            "_eq": true
+                          }
+                        }
+                      }
+                    }
+                  },
                   "allow_aggregations": true
                 },
                 "comment": ""
@@ -235,7 +259,8 @@
                 "permission": {
                   "columns": [
                     "url",
-                    "id"
+                    "id",
+                    "enabled"
                   ],
                   "filter": {},
                   "allow_aggregations": true

--- a/src/test/kotlin/me/brosssh/bundles/api/v3/routes/SourceRoutesTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/api/v3/routes/SourceRoutesTest.kt
@@ -1,0 +1,126 @@
+package me.brosssh.bundles.api.v3.routes
+
+import io.ktor.client.request.delete
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import me.brosssh.bundles.domain.models.SourceDeletionResult
+import me.brosssh.bundles.plugins.configureSerialization
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SourceRoutesTest {
+    @Test
+    fun `missing or invalid admin secret is rejected before deletion`() = testApplication {
+        var invoked = false
+        application {
+            configureSerialization()
+            routing {
+                route("/api/v3") {
+                    sourceRoutes(ADMIN_SECRET) {
+                        invoked = true
+                        SourceDeletionResult.NotFound
+                    }
+                }
+            }
+        }
+
+        val missing = client.delete("/api/v3/source") {
+            parameter("source_url", SOURCE_URL)
+        }
+        val invalid = client.delete("/api/v3/source") {
+            parameter("source_url", SOURCE_URL)
+            header(HASURA_ADMIN_SECRET_HEADER, "invalid")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, missing.status)
+        assertEquals(HttpStatusCode.Unauthorized, invalid.status)
+        assertFalse(invoked)
+    }
+
+    @Test
+    fun `valid admin secret deletes the canonical source and reports counts`() = testApplication {
+        var deletedSourceUrl: String? = null
+        application {
+            configureSerialization()
+            routing {
+                route("/api/v3") {
+                    sourceRoutes(ADMIN_SECRET) { sourceUrl ->
+                        deletedSourceUrl = sourceUrl
+                        SourceDeletionResult.Deleted(sources = 1, bundles = 3, patches = 7)
+                    }
+                }
+            }
+        }
+
+        val response = client.delete("/api/v3/source") {
+            parameter("source_url", "$SOURCE_URL/")
+            header(HASURA_ADMIN_SECRET_HEADER, ADMIN_SECRET)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(SOURCE_URL, deletedSourceUrl)
+        assertEquals(
+            """{"deleted_sources":1,"deleted_bundles":3,"deleted_patches":7}""",
+            response.bodyAsText()
+        )
+    }
+
+    @Test
+    fun `enabled source is rejected`() = testApplication {
+        var invoked = false
+        application {
+            configureSerialization()
+            routing {
+                route("/api/v3") {
+                    sourceRoutes(ADMIN_SECRET) {
+                        invoked = true
+                        SourceDeletionResult.Enabled
+                    }
+                }
+            }
+        }
+
+        val response = client.delete("/api/v3/source") {
+            parameter("source_url", SOURCE_URL)
+            header(HASURA_ADMIN_SECRET_HEADER, ADMIN_SECRET)
+        }
+
+        assertEquals(HttpStatusCode.Conflict, response.status)
+        assertTrue(invoked)
+    }
+
+    @Test
+    fun `missing source URL is rejected before deletion`() = testApplication {
+        var invoked = false
+        application {
+            configureSerialization()
+            routing {
+                route("/api/v3") {
+                    sourceRoutes(ADMIN_SECRET) {
+                        invoked = true
+                        SourceDeletionResult.NotFound
+                    }
+                }
+            }
+        }
+
+        val response = client.delete("/api/v3/source") {
+            header(HASURA_ADMIN_SECRET_HEADER, ADMIN_SECRET)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertFalse(invoked)
+    }
+
+    private companion object {
+        const val ADMIN_SECRET = "hasura-admin-secret"
+        const val SOURCE_URL = "https://github.com/example/patches"
+    }
+}

--- a/src/test/kotlin/me/brosssh/bundles/db/HasuraMetadataTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/db/HasuraMetadataTest.kt
@@ -1,0 +1,66 @@
+package me.brosssh.bundles.db
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HasuraMetadataTest {
+    private val tables: JsonArray by lazy {
+        val metadata = requireNotNull(javaClass.getResourceAsStream("/hasura/metadata.json"))
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+        metadata["metadata"]!!.jsonObject["sources"]!!.jsonArray
+            .single().jsonObject["tables"]!!.jsonArray
+    }
+
+    @Test
+    fun `public bundle and patch data requires an enabled source`() {
+        assertEquals(enabledSourceFilter(), userFilter("bundle"))
+        assertEquals(
+            buildJsonObject { put("bundle", enabledSourceFilter()) },
+            userFilter("patch")
+        )
+        assertEquals(
+            buildJsonObject {
+                put("patch", buildJsonObject { put("bundle", enabledSourceFilter()) })
+            },
+            userFilter("patch_package")
+        )
+    }
+
+    @Test
+    fun `public source list includes enabled state without filtering disabled sources`() {
+        val permission = userPermission("source")
+        val columns = permission["columns"]!!.jsonArray.map { it.jsonPrimitive.content }
+
+        assertTrue("enabled" in columns)
+        assertEquals(JsonObject(emptyMap()), permission["filter"])
+    }
+
+    private fun enabledSourceFilter() = buildJsonObject {
+        put("source", buildJsonObject {
+            put("enabled", buildJsonObject {
+                put("_eq", JsonPrimitive(true))
+            })
+        })
+    }
+
+    private fun userFilter(tableName: String) = userPermission(tableName)["filter"]!!.jsonObject
+
+    private fun userPermission(tableName: String): JsonObject {
+        val table = tables.single {
+            it.jsonObject["table"]!!.jsonObject["name"]!!.jsonPrimitive.content == tableName
+        }.jsonObject
+        return table["select_permissions"]!!.jsonArray.single {
+            it.jsonObject["role"]!!.jsonPrimitive.content == "user"
+        }.jsonObject["permission"]!!.jsonObject
+    }
+}

--- a/src/test/kotlin/me/brosssh/bundles/repositories/DisabledSourceRepositoryTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/repositories/DisabledSourceRepositoryTest.kt
@@ -1,0 +1,177 @@
+package me.brosssh.bundles.repositories
+
+import me.brosssh.bundles.db.tables.BundleTable
+import me.brosssh.bundles.db.tables.PackageTable
+import me.brosssh.bundles.db.tables.PatchPackageTable
+import me.brosssh.bundles.db.tables.PatchTable
+import me.brosssh.bundles.db.tables.SourceMetadataTable
+import me.brosssh.bundles.db.tables.SourceTable
+import me.brosssh.bundles.domain.models.BundleType
+import me.brosssh.bundles.domain.models.ReleaseChannel
+import me.brosssh.bundles.domain.models.SourceDeletionResult
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class DisabledSourceRepositoryTest {
+    private lateinit var database: Database
+
+    @BeforeTest
+    fun setUp() {
+        database = Database.connect(
+            url = "jdbc:h2:mem:${UUID.randomUUID()};MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+            driver = "org.h2.Driver"
+        )
+        TransactionManager.defaultDatabase = database
+        transaction(database) {
+            SchemaUtils.create(
+                SourceTable,
+                SourceMetadataTable,
+                BundleTable,
+                PatchTable,
+                PackageTable,
+                PatchPackageTable
+            )
+        }
+    }
+
+    @Test
+    fun `legacy lookups hide disabled bundles while explicit source lookups retain access`() {
+        val fixture = insertSource(enabled = false)
+        val repository = BundleRepository()
+
+        assertNull(repository.findById(fixture.bundleId))
+        assertNull(repository.findLatestByRepo(OWNER, REPO, prerelease = false))
+        assertNull(repository.findByRepoAndVersion(OWNER, REPO, VERSION))
+        assertNull(repository.findByRepoAndChannel(OWNER, REPO, ReleaseChannel.STABLE))
+        assertTrue(repository.getBundlesNeedPatchesUpdate().isEmpty())
+
+        assertNotNull(repository.findBySourceAndChannel(SOURCE_URL, ReleaseChannel.STABLE))
+        assertNotNull(repository.findBySourceAndVersion(SOURCE_URL, VERSION, ReleaseChannel.STABLE))
+
+        transaction(database) {
+            SourceTable.update({ SourceTable.id eq fixture.sourceId }) {
+                it[enabled] = true
+            }
+        }
+
+        assertNotNull(repository.findById(fixture.bundleId))
+        assertNotNull(repository.findLatestByRepo(OWNER, REPO, prerelease = false))
+        assertNotNull(repository.findByRepoAndVersion(OWNER, REPO, VERSION))
+        assertNotNull(repository.findByRepoAndChannel(OWNER, REPO, ReleaseChannel.STABLE))
+        assertEquals(1, repository.getBundlesNeedPatchesUpdate().size)
+    }
+
+    @Test
+    fun `hard deletion removes a disabled source and its owned rows`() {
+        insertSource(enabled = false, patchCount = 2)
+
+        val result = assertIs<SourceDeletionResult.Deleted>(
+            SourceRepository().hardDelete(SOURCE_URL)
+        )
+
+        assertEquals(1, result.sources)
+        assertEquals(1, result.bundles)
+        assertEquals(2, result.patches)
+        transaction(database) {
+            assertEquals(0, SourceTable.selectAll().count())
+            assertEquals(0, SourceMetadataTable.selectAll().count())
+            assertEquals(0, BundleTable.selectAll().count())
+            assertEquals(0, PatchTable.selectAll().count())
+            assertEquals(0, PatchPackageTable.selectAll().count())
+            assertEquals(1, PackageTable.selectAll().count())
+        }
+    }
+
+    @Test
+    fun `hard deletion rejects an enabled source without changing it`() {
+        insertSource(enabled = true)
+
+        assertSame(SourceDeletionResult.Enabled, SourceRepository().hardDelete(SOURCE_URL))
+
+        transaction(database) {
+            assertEquals(1, SourceTable.selectAll().count())
+            assertEquals(1, SourceMetadataTable.selectAll().count())
+            assertEquals(1, BundleTable.selectAll().count())
+        }
+    }
+
+    @Test
+    fun `hard deletion reports an unknown source`() {
+        assertSame(SourceDeletionResult.NotFound, SourceRepository().hardDelete(SOURCE_URL))
+    }
+
+    private fun insertSource(enabled: Boolean, patchCount: Int = 1): Fixture = transaction(database) {
+        val sourceId = SourceTable.insertAndGetId {
+            it[url] = SOURCE_URL
+            it[SourceTable.enabled] = enabled
+        }
+        SourceMetadataTable.insert {
+            it[sourceFk] = sourceId
+            it[ownerName] = OWNER
+            it[ownerAvatarUrl] = "https://example.com/avatar.png"
+            it[repoName] = REPO
+            it[repoDescription] = null
+            it[repoStars] = 1
+            it[isRepoArchived] = false
+            it[repoPushedAt] = "2026-03-25T00:00:00Z"
+        }
+        val bundleId = BundleTable.insertAndGetId {
+            it[version] = VERSION
+            it[createdAt] = "2026-03-25T00:00:00Z"
+            it[description] = null
+            it[downloadUrl] = "https://example.com/bundle.rvp"
+            it[signatureDownloadUrl] = null
+            it[isPrerelease] = false
+            it[isLatest] = true
+            it[fileHash] = null
+            it[needPatchesUpdate] = true
+            it[bundleType] = BundleType.REVANCED_V4.value
+            it[sourceFk] = sourceId
+        }
+        val packageId = PackageTable.insertAndGetId {
+            it[name] = "com.example.app"
+            it[version] = null
+        }
+        repeat(patchCount) { index ->
+            val patchId = PatchTable.insertAndGetId {
+                it[bundleFk] = bundleId
+                it[name] = "Patch $index"
+                it[description] = null
+            }
+            PatchPackageTable.insert {
+                it[patchFk] = patchId
+                it[packageFk] = packageId
+            }
+        }
+
+        Fixture(sourceId.value, bundleId.value)
+    }
+
+    private data class Fixture(
+        val sourceId: Int,
+        val bundleId: Int
+    )
+
+    private companion object {
+        const val SOURCE_URL = "https://github.com/example/patches"
+        const val OWNER = "example"
+        const val REPO = "patches"
+        const val VERSION = "v1.0.0"
+    }
+}


### PR DESCRIPTION
## Summary

This makes `source.enabled` a publishing state rather than only a refresh switch.

Disabled sources remain in the database and continue to appear in the Hasura source list with `enabled = false`. Their bundles and patches are hidden from public Hasura queries, the frontend, and v1/v2. Explicit v3 requests continue to serve cached bundles when the caller provides the source URL.

Bundle refresh and pending patch extraction both skip disabled sources. Re-enabling a source makes its cached data public again without requiring a refresh.

Closes #42.

## Hard deletion

Adds an operator endpoint for deleting a disabled source and its cached data:

```http
DELETE /api/v3/source?source_url=https://github.com/owner/repository
X-Hasura-Admin-Secret: <admin-secret>
```

The endpoint:

- accepts only the configured `HASURA_GRAPHQL_ADMIN_SECRET`
- rejects enabled sources
- deletes source metadata, bundles, patches, and the source in one transaction
- returns the numbers of deleted sources, bundles, and patches

The source must first be removed from `sources.toml` and synchronized as disabled. Leaving it in the manifest, even with `enabled = false`, allows startup synchronization to recreate the row after deletion.

The Hasura admin-secret header is redacted by Ktor client logging.

## Behavior

| Surface                                | Disabled source                |
|----------------------------------------|--------------------------------|
| Bundle refresh                         | Excluded                       |
| Patch extraction                       | Excluded                       |
| Hasura source list                     | Visible with `enabled = false` |
| Public Hasura bundle and patch queries | Hidden                         |
| Frontend                               | Hidden                         |
| v1 and v2                              | Not found                      |
| Explicit v3 exact-version request      | Available from cache           |
| Explicit v3 latest request             | Available from cache           |
| Hasura admin-secret query              | Available                      |

## Testing

H2 was added for isolated repository tests using PostgreSQL compatibility mode.

- Disabled bundles are hidden from v1, v2, and public Hasura queries.
- Explicit v3 requests still return cached bundles.
- Refresh jobs skip disabled sources, and re-enabling restores visibility.
- Hard deletion requires the admin secret, rejects enabled sources, and removes cached data transactionally.
