### PR TITLE
feat(web-ui): improve bundle browser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,4 +35,6 @@ BACKEND_PATCHER_WORKER_IDLE_SECONDS=300
 BACKEND_PATCHER_REFRESH_CONCURRENCY=4
 
 HASURA_PORT=8082
+# Set a non-empty value. Leaving this empty causes admin authentication and
+# actions to behave inconsistently.
 HASURA_GRAPHQL_ADMIN_SECRET=

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,8 @@ dependencies {
     implementation(libs.semver4j)
 
     testImplementation(libs.kotlin.test)
+    testImplementation(libs.ktor.test.host)
+    testRuntimeOnly(libs.h2)
 }
 
 tasks.test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ ktor = "3.2.3"
 exposed = "1.0.0-rc-4"
 hikari = "5.1.0"
 postgresql = "42.7.3"
+h2 = "2.3.232"
 koin = "3.5.3"
 openapi-tools = "5.4.0"
 dotenv = "6.5.1"
@@ -20,6 +21,7 @@ ktor-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation-j
 ktor-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json-jvm", version.ref = "ktor" }
 ktor-call-logging = { module = "io.ktor:ktor-server-call-logging-jvm", version.ref = "ktor" }
 ktor-auth = { module = "io.ktor:ktor-server-auth-jvm", version.ref = "ktor" }
+ktor-test-host = { module = "io.ktor:ktor-server-test-host-jvm", version.ref = "ktor" }
 
 # Ktor client
 ktor-client-core = { module = "io.ktor:ktor-client-core-jvm", version.ref = "ktor" }
@@ -45,6 +47,7 @@ exposed-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetime", v
 # Hikari & Postgres
 hikari-cp = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
+h2 = { module = "com.h2database:h2", version.ref = "h2" }
 
 # Other
 dotenv = { module = "io.github.cdimascio:dotenv-kotlin", version.ref = "dotenv" }

--- a/src/main/kotlin/me/brosssh/bundles/Application.kt
+++ b/src/main/kotlin/me/brosssh/bundles/Application.kt
@@ -8,6 +8,7 @@ import io.ktor.server.netty.*
 import io.ktor.server.routing.*
 import io.ktor.server.routing.IgnoreTrailingSlash
 import me.brosssh.bundles.api.v3.routes.bundleRoutes as bundleRoutesV3
+import me.brosssh.bundles.api.v3.routes.sourceRoutes
 import me.brosssh.bundles.api.routes.graphQLRoute
 import me.brosssh.bundles.api.v1.routes.bundleRoutes as bundleRoutesV1
 import me.brosssh.bundles.api.v1.routes.refreshRoutes
@@ -15,6 +16,7 @@ import me.brosssh.bundles.api.v2.routes.bundleRoutes as bundleRoutesV2
 import me.brosssh.bundles.db.SourceManifestSync
 import me.brosssh.bundles.db.migration.applyHasuraMetadata
 import me.brosssh.bundles.db.migration.migrationScript
+import me.brosssh.bundles.domain.services.SourceService
 import me.brosssh.bundles.plugins.*
 import org.koin.ktor.ext.inject
 
@@ -42,6 +44,7 @@ suspend fun Application.module() {
     migrationScript()
 
     val sourceManifestSync by inject<SourceManifestSync>()
+    val sourceService by inject<SourceService>()
     log.info(sourceManifestSync.sync().summary)
 
     applyHasuraMetadata()
@@ -65,6 +68,7 @@ suspend fun Application.module() {
 
         apiV3 {
             bundleRoutesV3()
+            sourceRoutes(Config.hasuraSecret, sourceService::hardDelete)
         }
 
         graphQLRoute()

--- a/src/main/kotlin/me/brosssh/bundles/api/v3/dto/SourceDeletionResponseDto.kt
+++ b/src/main/kotlin/me/brosssh/bundles/api/v3/dto/SourceDeletionResponseDto.kt
@@ -1,0 +1,21 @@
+package me.brosssh.bundles.api.v3.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import me.brosssh.bundles.domain.models.SourceDeletionResult
+
+@Serializable
+data class SourceDeletionResponseDto(
+    @SerialName("deleted_sources")
+    val deletedSources: Int,
+    @SerialName("deleted_bundles")
+    val deletedBundles: Int,
+    @SerialName("deleted_patches")
+    val deletedPatches: Int
+)
+
+fun SourceDeletionResult.Deleted.toResponseDto() = SourceDeletionResponseDto(
+    deletedSources = sources,
+    deletedBundles = bundles,
+    deletedPatches = patches
+)

--- a/src/main/kotlin/me/brosssh/bundles/api/v3/routes/SourceRoutes.kt
+++ b/src/main/kotlin/me/brosssh/bundles/api/v3/routes/SourceRoutes.kt
@@ -1,0 +1,110 @@
+package me.brosssh.bundles.api.v3.routes
+
+import io.github.smiley4.ktoropenapi.delete
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.header
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.route
+import me.brosssh.bundles.api.v3.dto.SourceDeletionResponseDto
+import me.brosssh.bundles.api.v3.dto.toResponseDto
+import me.brosssh.bundles.domain.models.SourceDeletionResult
+import me.brosssh.bundles.integrations.common.parseRepoUrl
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+internal const val HASURA_ADMIN_SECRET_HEADER = "X-Hasura-Admin-Secret"
+
+internal fun matchesAdminSecret(provided: String?, expected: String): Boolean =
+    provided != null &&
+            expected.isNotEmpty() &&
+            MessageDigest.isEqual(
+                provided.toByteArray(StandardCharsets.UTF_8),
+                expected.toByteArray(StandardCharsets.UTF_8)
+            )
+
+fun Route.sourceRoutes(
+    hasuraAdminSecret: String,
+    hardDeleteSource: (String) -> SourceDeletionResult
+) {
+    route("/source") {
+        delete("", {
+            summary = "Hard-delete a disabled source"
+            description = "Deletes a disabled source and its cached bundles and patches. " +
+                    "Requires the configured Hasura admin secret."
+            tags = listOf("Source v3")
+
+            request {
+                queryParameter<String>("source_url") {
+                    description = "Canonical URL of the disabled source"
+                    required = true
+                }
+                headerParameter<String>(HASURA_ADMIN_SECRET_HEADER) {
+                    description = "Hasura admin secret"
+                    required = true
+                }
+            }
+
+            response {
+                HttpStatusCode.OK to {
+                    description = "Source and cached data deleted"
+                    body<SourceDeletionResponseDto>()
+                }
+                HttpStatusCode.BadRequest to {
+                    description = "Invalid or missing source URL"
+                    body<Map<String, String>>()
+                }
+                HttpStatusCode.Unauthorized to {
+                    description = "Missing or invalid admin secret"
+                    body<Map<String, String>>()
+                }
+                HttpStatusCode.NotFound to {
+                    description = "Source not found"
+                    body<Map<String, String>>()
+                }
+                HttpStatusCode.Conflict to {
+                    description = "Source is still enabled"
+                    body<Map<String, String>>()
+                }
+            }
+        }) {
+            if (!matchesAdminSecret(call.request.header(HASURA_ADMIN_SECRET_HEADER), hasuraAdminSecret)) {
+                return@delete call.respond(
+                    HttpStatusCode.Unauthorized,
+                    mapOf("error" to "Missing or invalid admin secret.")
+                )
+            }
+
+            val sourceUrl = call.request.queryParameters["source_url"]
+                ?: return@delete call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf("error" to "Missing 'source_url' query parameter.")
+                )
+            val source = try {
+                parseRepoUrl(sourceUrl)
+            } catch (error: IllegalArgumentException) {
+                return@delete call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf("error" to (error.message ?: "Invalid 'source_url' query parameter."))
+                )
+            }
+
+            when (val result = hardDeleteSource(source.canonicalUrl)) {
+                SourceDeletionResult.NotFound -> call.respond(
+                    HttpStatusCode.NotFound,
+                    mapOf("error" to "Source not found.")
+                )
+
+                SourceDeletionResult.Enabled -> call.respond(
+                    HttpStatusCode.Conflict,
+                    mapOf("error" to "Source must be disabled before hard deletion.")
+                )
+
+                is SourceDeletionResult.Deleted -> call.respond(
+                    HttpStatusCode.OK,
+                    result.toResponseDto()
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/me/brosssh/bundles/di/AppModule.kt
+++ b/src/main/kotlin/me/brosssh/bundles/di/AppModule.kt
@@ -6,6 +6,7 @@ import me.brosssh.bundles.Config
 import me.brosssh.bundles.db.SourceManifestSync
 import me.brosssh.bundles.domain.services.BundleService
 import me.brosssh.bundles.domain.services.RefreshJobStatusService
+import me.brosssh.bundles.domain.services.SourceService
 import me.brosssh.bundles.domain.services.jobs.RefreshAllJobService
 import me.brosssh.bundles.domain.services.jobs.RefreshBundlesJobService
 import me.brosssh.bundles.domain.services.jobs.RefreshPatchesJobService
@@ -92,6 +93,7 @@ val appModule = module {
     }
 
     single { BundleService(get()) }
+    single { SourceService(get()) }
     single { RefreshJobStatusService(get()) }
     single { SourceManifestSync(get()) }
 

--- a/src/main/kotlin/me/brosssh/bundles/di/HttpClient.kt
+++ b/src/main/kotlin/me/brosssh/bundles/di/HttpClient.kt
@@ -32,7 +32,8 @@ val httpClientModule = module {
                 level = LogLevel.INFO
                 sanitizeHeader { header ->
                     header.equals(HttpHeaders.Authorization, ignoreCase = true) ||
-                        header.equals("PRIVATE-TOKEN", ignoreCase = true)
+                        header.equals("PRIVATE-TOKEN", ignoreCase = true) ||
+                        header.equals("X-Hasura-Admin-Secret", ignoreCase = true)
                 }
             }
         }

--- a/src/main/kotlin/me/brosssh/bundles/domain/models/SourceDeletionResult.kt
+++ b/src/main/kotlin/me/brosssh/bundles/domain/models/SourceDeletionResult.kt
@@ -1,0 +1,13 @@
+package me.brosssh.bundles.domain.models
+
+sealed interface SourceDeletionResult {
+    data object NotFound : SourceDeletionResult
+
+    data object Enabled : SourceDeletionResult
+
+    data class Deleted(
+        val sources: Int,
+        val bundles: Int,
+        val patches: Int
+    ) : SourceDeletionResult
+}

--- a/src/main/kotlin/me/brosssh/bundles/domain/services/SourceService.kt
+++ b/src/main/kotlin/me/brosssh/bundles/domain/services/SourceService.kt
@@ -1,0 +1,9 @@
+package me.brosssh.bundles.domain.services
+
+import me.brosssh.bundles.repositories.SourceRepository
+
+class SourceService(
+    private val sourceRepository: SourceRepository
+) {
+    fun hardDelete(sourceUrl: String) = sourceRepository.hardDelete(sourceUrl)
+}

--- a/src/main/kotlin/me/brosssh/bundles/repositories/BundleRepository.kt
+++ b/src/main/kotlin/me/brosssh/bundles/repositories/BundleRepository.kt
@@ -23,9 +23,11 @@ data class BundlePatchCandidate(
 
 class BundleRepository {
     fun findById(bundleId: Int) = transaction {
-        BundleTable
+        (BundleTable innerJoin SourceTable)
             .selectAll()
-            .where { BundleTable.id eq bundleId }
+            .where {
+                (BundleTable.id eq bundleId) and enabledSourceFilter
+            }
             .limit(1)
             .map(::rowToDomain)
             .singleOrNull()
@@ -77,9 +79,11 @@ class BundleRepository {
     }
 
     fun getBundlesNeedPatchesUpdate() = transaction {
-        BundleTable
+        (BundleTable innerJoin SourceTable)
             .selectAll()
-            .where { BundleTable.needPatchesUpdate eq true }
+            .where {
+                (BundleTable.needPatchesUpdate eq true) and enabledSourceFilter
+            }
             .map { row ->
                 BundlePatchCandidate(
                     id = row[BundleTable.id].value,
@@ -132,7 +136,8 @@ class BundleRepository {
         (BundleTable innerJoin SourceTable innerJoin SourceMetadataTable)
             .selectAll()
             .where {
-                (SourceMetadataTable.ownerName eq owner) and
+                enabledSourceFilter and
+                        (SourceMetadataTable.ownerName eq owner) and
                         (SourceMetadataTable.repoName eq repo) and
                         (BundleTable.isPrerelease eq prerelease) and
                         (BundleTable.isLatest eq true)
@@ -146,7 +151,8 @@ class BundleRepository {
         (BundleTable innerJoin SourceTable innerJoin SourceMetadataTable)
             .selectAll()
             .where {
-                (SourceMetadataTable.ownerName eq owner) and
+                enabledSourceFilter and
+                        (SourceMetadataTable.ownerName eq owner) and
                         (SourceMetadataTable.repoName eq repo) and
                         (BundleTable.version eq version)
             }
@@ -159,7 +165,8 @@ class BundleRepository {
         (BundleTable innerJoin SourceTable innerJoin SourceMetadataTable)
             .selectAll()
             .where {
-                (SourceMetadataTable.ownerName eq owner) and
+                enabledSourceFilter and
+                        (SourceMetadataTable.ownerName eq owner) and
                         (SourceMetadataTable.repoName eq repo) and
                         (BundleTable.isLatest eq true) and
                         channel.releaseFilter
@@ -201,6 +208,10 @@ class BundleRepository {
             .map(::rowToDomain)
             .singleOrNull()
     }
+
+    // v1 and v2 expose only bundles from enabled sources; explicit v3 lookups do not use this filter.
+    private val enabledSourceFilter: Op<Boolean>
+        get() = SourceTable.enabled eq true
 
     private fun sourceUrlFilter(sourceUrl: String) =
         (SourceTable.url eq sourceUrl) or (SourceTable.url eq "$sourceUrl/")

--- a/src/main/kotlin/me/brosssh/bundles/repositories/SourceRepository.kt
+++ b/src/main/kotlin/me/brosssh/bundles/repositories/SourceRepository.kt
@@ -1,12 +1,60 @@
 package me.brosssh.bundles.repositories
 
 import me.brosssh.bundles.db.entities.SourceEntity
+import me.brosssh.bundles.db.tables.BundleTable
+import me.brosssh.bundles.db.tables.PatchTable
+import me.brosssh.bundles.db.tables.SourceMetadataTable
 import me.brosssh.bundles.db.tables.SourceTable
+import me.brosssh.bundles.domain.models.SourceDeletionResult
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 class SourceRepository {
     fun getEnabled(): List<SourceEntity> = transaction {
         SourceEntity.find { SourceTable.enabled eq true }.toList()
+    }
+
+    fun hardDelete(sourceUrl: String): SourceDeletionResult = transaction {
+        val sourceRows = SourceTable
+            .selectAll()
+            .where {
+                (SourceTable.url eq sourceUrl) or (SourceTable.url eq "$sourceUrl/")
+            }
+            .forUpdate()
+            .toList()
+
+        if (sourceRows.isEmpty()) return@transaction SourceDeletionResult.NotFound
+        if (sourceRows.any { it[SourceTable.enabled] }) {
+            return@transaction SourceDeletionResult.Enabled
+        }
+
+        val sourceIds = sourceRows.map { it[SourceTable.id] }
+        val bundleIds = BundleTable
+            .selectAll()
+            .where { BundleTable.sourceFk inList sourceIds }
+            .map { it[BundleTable.id] }
+        val patchCount = if (bundleIds.isEmpty()) {
+            0
+        } else {
+            PatchTable
+                .selectAll()
+                .where { PatchTable.bundleFk inList bundleIds }
+                .count()
+                .toInt()
+        }
+
+        SourceMetadataTable.deleteWhere { SourceMetadataTable.sourceFk inList sourceIds }
+        val bundleCount = BundleTable.deleteWhere { BundleTable.sourceFk inList sourceIds }
+        val sourceCount = SourceTable.deleteWhere { SourceTable.id inList sourceIds }
+
+        SourceDeletionResult.Deleted(
+            sources = sourceCount,
+            bundles = bundleCount,
+            patches = patchCount
+        )
     }
 }

--- a/src/main/resources/hasura/metadata.json
+++ b/src/main/resources/hasura/metadata.json
@@ -52,7 +52,13 @@
                     "source_fk",
                     "description"
                   ],
-                  "filter": {},
+                  "filter": {
+                    "source": {
+                      "enabled": {
+                        "_eq": true
+                      }
+                    }
+                  },
                   "allow_aggregations": true
                 },
                 "comment": ""
@@ -131,7 +137,15 @@
                     "id",
                     "description"
                   ],
-                  "filter": {},
+                  "filter": {
+                    "bundle": {
+                      "source": {
+                        "enabled": {
+                          "_eq": true
+                        }
+                      }
+                    }
+                  },
                   "allow_aggregations": true
                 },
                 "comment": ""
@@ -165,7 +179,17 @@
                     "package_fk",
                     "patch_fk"
                   ],
-                  "filter": {},
+                  "filter": {
+                    "patch": {
+                      "bundle": {
+                        "source": {
+                          "enabled": {
+                            "_eq": true
+                          }
+                        }
+                      }
+                    }
+                  },
                   "allow_aggregations": true
                 },
                 "comment": ""
@@ -235,7 +259,8 @@
                 "permission": {
                   "columns": [
                     "url",
-                    "id"
+                    "id",
+                    "enabled"
                   ],
                   "filter": {},
                   "allow_aggregations": true

--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -141,7 +141,9 @@ function clearVirtualizer() {
 
 
 function currentAnchorBundleIndex() {
-    if (!virtualizer) return 0;
+    if (!virtualizer) return null;
+    const trackTop = track.getBoundingClientRect().top + window.scrollY;
+    if (window.scrollY < trackTop) return null;
     const visibleRow = virtualizer.getVirtualItems()
         .find(item => item.end >= window.scrollY);
     return (visibleRow?.index ?? 0) * lastColumns;

--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -1,123 +1,662 @@
+import {
+    Virtualizer,
+    measureElement,
+    observeWindowOffset,
+    observeWindowRect,
+    windowScroll
+} from "https://esm.sh/@tanstack/virtual-core@3.17.8?bundle";
+
+/* global DOMPurify, marked */
+
 const input = document.getElementById("search");
 const packageFilter = document.getElementById("package-filter");
+const sourceFilter = document.getElementById("source-filter");
+const bundleVersionFilter = document.getElementById("bundle-version-filter");
+const bundleTypeFilter = document.getElementById("bundle-type-filter");
 const results = document.getElementById("results");
 const status = document.getElementById("status");
+const toggleAllChangelogs = document.getElementById("toggle-all-changelogs");
+const viewToggle = document.getElementById("view-toggle");
+const container = document.querySelector(".container");
 const filterButtons = document.querySelectorAll(".filter-btn");
+const adminAccess = document.getElementById("admin-access");
+const disabledSourcesToggle = document.getElementById("disabled-sources-toggle");
+
+// Keep the denser list layout as the mobile default; desktop starts in grid view.
+if (matchMedia("(max-width: 700px)").matches) {
+    results.classList.remove("grid-view");
+    container.classList.remove("grid-view-enabled");
+    viewToggle.setAttribute("aria-pressed", "false");
+    viewToggle.textContent = "Grid view";
+}
+
+// Virtualized list: TanStack Virtual renders only the visible rows of cards. Row
+// heights are measured from the DOM and a single spacer keeps the document scroll
+// height correct, so card positions are stable and no scroll compensation is needed.
+const ROW_GAP = 16;
+const MIN_COLUMN_WIDTH = 380;
+
+// Parsed markdown/patches reuse: rows are recreated as the viewport moves, so
+// re-parsing the same bundle's changelog every time dominates re-render cost.
+const renderCache = new Map();
+const patchListCache = new WeakMap();
+const cardViewStates = new Map();
+const RENDER_CACHE_LIMIT = 500;
+marked.setOptions({ breaks: true, gfm: true });
+
+function cachedMarkdown(bundleId, key, markdown) {
+    const cacheKey = `${bundleId}:${key}`;
+    let html = renderCache.get(cacheKey);
+    if (html === undefined) {
+        html = renderMarkdown(markdown);
+        if (renderCache.size >= RENDER_CACHE_LIMIT) renderCache.clear();
+        renderCache.set(cacheKey, html);
+    }
+    return html;
+}
+
+function cachedPatchList(patches) {
+    let html = patchListCache.get(patches);
+    if (html === undefined) {
+        html = patches.map(renderPatch).join('');
+        patchListCache.set(patches, html);
+    }
+    return html;
+}
+
+function restoreScrollTop(element, scrollTop) {
+    element.scrollTop = scrollTop;
+    queueMicrotask(() => {
+        if (element.isConnected && !element.hidden) element.scrollTop = scrollTop;
+    });
+}
+
+const track = document.getElementById("v-track");
+let filteredBundles = [];
+let virtualizer = null;
+let rowData = [];
+let lastColumns = 1;
+let lastVisibleFp = "";
+
+function layoutColumns() {
+    if (!results.classList.contains("grid-view")) return 1;
+    const width = results.clientWidth;
+    return Math.max(1, Math.floor((width + ROW_GAP) / (MIN_COLUMN_WIDTH + ROW_GAP)));
+}
+
+function buildRows() {
+    const columns = layoutColumns();
+    const rows = [];
+    for (let i = 0; i < filteredBundles.length; i += columns) {
+        rows.push(filteredBundles.slice(i, i + columns));
+    }
+    return rows;
+}
+
+function estimateRowHeight() {
+    // Guess only: measured row heights replace this as rows render.
+    return results.classList.contains("grid-view") ? 420 : 300;
+}
+
+function renderVisible() {
+    if (!virtualizer || rowData.length === 0) return;
+
+    const items = virtualizer.getVirtualItems();
+    const fp = items.map(v => `${v.index}:${Math.round(v.start)}`).join(",");
+    if (fp === lastVisibleFp) {
+        track.style.height = `${virtualizer.getTotalSize()}px`;
+        return;
+    }
+    lastVisibleFp = fp;
+
+    track.style.height = `${virtualizer.getTotalSize()}px`;
+    const fragment = document.createDocumentFragment();
+    const columns = layoutColumns();
+    for (const item of items) {
+        const rowEl = document.createElement("div");
+        rowEl.className = "virtual-row";
+        rowEl.dataset.index = String(item.index);
+        rowEl.style.transform = `translateY(${item.start - virtualizer.options.scrollMargin}px)`;
+        rowEl.style.gridTemplateColumns = `repeat(${columns}, minmax(0, 1fr))`;
+        for (const card of rowData[item.index]) {
+            if (card.isDisabledSourceCard) renderDisabledSource(card, rowEl);
+            else renderBundle(card, rowEl);
+        }
+        fragment.appendChild(rowEl);
+    }
+    track.replaceChildren(fragment);
+    virtualizer.measureElement(null);
+    for (const rowEl of track.children) virtualizer.measureElement(rowEl);
+    updateAllChangelogsButton();
+}
+
+function clearVirtualizer() {
+    if (virtualizer) virtualizer.cleanup();
+    virtualizer = null;
+    rowData = [];
+    lastVisibleFp = "";
+    track.replaceChildren();
+    track.style.height = "0px";
+}
+
+
+function currentAnchorBundleIndex() {
+    if (!virtualizer) return 0;
+    const visibleRow = virtualizer.getVirtualItems()
+        .find(item => item.end >= window.scrollY);
+    return (visibleRow?.index ?? 0) * lastColumns;
+}
+
+function setupVirtualizer(anchorBundleIndex = null) {
+    rowData = buildRows();
+    lastColumns = layoutColumns();
+    if (virtualizer) virtualizer.cleanup();
+    virtualizer = new Virtualizer({
+        count: rowData.length,
+        getScrollElement: () => window,
+        estimateSize: () => estimateRowHeight(),
+        initialOffset: () => window.scrollY,
+        scrollMargin: track.getBoundingClientRect().top + window.scrollY,
+        overscan: 2,
+        gap: ROW_GAP,
+        observeElementRect: observeWindowRect,
+        observeElementOffset: observeWindowOffset,
+        scrollToFn: windowScroll,
+        measureElement,
+        onChange: () => renderVisible()
+    });
+    // The vanilla core does not attach its scroll/resize observers until
+    // _willUpdate is invoked; without it no viewport rows ever render.
+    virtualizer._willUpdate();
+    lastVisibleFp = "";
+    renderVisible();
+    if (anchorBundleIndex !== null && rowData.length > 0) {
+        virtualizer.scrollToIndex(
+            Math.min(Math.floor(anchorBundleIndex / lastColumns), rowData.length - 1),
+            { align: "start" }
+        );
+    }
+}
+
+const BUNDLE_FIELDS = `
+    id
+    bundle_type
+    created_at
+    description
+    download_url
+    signature_download_url
+    is_prerelease
+    version
+    source {
+         url
+         enabled
+        source_metadata: source_metadatum {
+            owner_name
+            owner_avatar_url
+            repo_name
+            repo_description
+            repo_stars
+            repo_pushed_at
+            is_repo_archived
+        }
+    }
+    patches {
+        name
+        description
+        patch_packages {
+            package {
+                name
+                version
+            }
+        }
+    }
+`;
 
 let currentFilter = "release";
 let currentSearchQuery = "";
 let currentPackageFilter = "";
+let currentSourceUrl = "";
+let currentBundleVersion = "";
+let currentBundleType = "";
+let latestBundles = [];
 let allBundles = [];
+let sourceVersions = [];
+let sourceRequestId = 0;
+let bundleRequestId = 0;
+let allChangelogsExpanded = true;
+const ADMIN_SECRET_STORAGE_KEY = "bundle-search-admin-secret";
 
-// Load bundles on page load
-loadBundles();
+let adminSecret = null;
+let adminEnabled = false;
+let disabledSources = [];
+let showingDisabledSources = false;
+
+
+function storedAdminSecret() {
+    try {
+        return sessionStorage.getItem(ADMIN_SECRET_STORAGE_KEY);
+    } catch {
+        return null;
+    }
+}
+
+function saveAdminSecret(secret) {
+    try {
+        sessionStorage.setItem(ADMIN_SECRET_STORAGE_KEY, secret);
+    } catch {
+        // Private browsing may disable session storage; admin access still works for this page.
+    }
+}
+
+function clearAdminSecret() {
+    try {
+        sessionStorage.removeItem(ADMIN_SECRET_STORAGE_KEY);
+    } catch {
+        // Nothing to clear when session storage is unavailable.
+    }
+}
+
+const renderAfterInput = debounce(() => {
+    renderFilteredBundles();
+}, 150);
+
+async function restoreAdminAccess() {
+    const secret = storedAdminSecret();
+    if (!secret) return loadBundles();
+
+    try {
+        await requestGraphQL("query ValidateAdmin { source(limit: 1) { id } }", {}, secret);
+        adminSecret = secret;
+        adminEnabled = true;
+        adminAccess.textContent = "Exit admin";
+        await loadBundles(adminSecret);
+    } catch {
+        clearAdminSecret();
+        await loadBundles();
+    }
+}
+
+void restoreAdminAccess();
+
+adminAccess.addEventListener("click", async () => {
+    if (adminEnabled) {
+        adminEnabled = false;
+        adminSecret = null;
+        showingDisabledSources = false;
+        disabledSourcesToggle.hidden = true;
+        disabledSourcesToggle.textContent = "Show disabled sources";
+        clearAdminSecret();
+        adminAccess.textContent = "Admin access";
+        await loadBundles();
+        return;
+    }
+
+    const secret = prompt("Hasura admin secret:");
+    if (!secret) return;
+
+    try {
+        await requestGraphQL("query ValidateAdmin { source(limit: 1) { id } }", {}, secret);
+        adminSecret = secret;
+        adminEnabled = true;
+        showingDisabledSources = false;
+        saveAdminSecret(secret);
+        adminAccess.textContent = "Exit admin";
+        await loadBundles(adminSecret);
+    } catch (error) {
+        adminSecret = null;
+        clearAdminSecret();
+        alert("Invalid Hasura admin secret.");
+    }
+});
 
 input.addEventListener("input", () => {
     currentSearchQuery = input.value.trim().toLowerCase();
-    renderFilteredBundles();
+    renderAfterInput();
 });
 
 packageFilter.addEventListener("input", () => {
     currentPackageFilter = packageFilter.value.trim().toLowerCase();
+    renderAfterInput();
+});
+
+sourceFilter.addEventListener("change", () => selectSource(sourceFilter.value));
+
+bundleVersionFilter.addEventListener("change", () => selectBundleVersion(bundleVersionFilter.value));
+
+bundleTypeFilter.addEventListener("change", () => {
+    currentBundleType = bundleTypeFilter.value;
+    resetBundleSelection();
+    populateVersionOptions();
     renderFilteredBundles();
 });
 
 filterButtons.forEach(btn => {
     btn.addEventListener("click", () => {
-        filterButtons.forEach(b => b.classList.remove("active"));
+        filterButtons.forEach(button => button.classList.remove("active"));
         btn.classList.add("active");
         currentFilter = btn.dataset.filter;
+        resetBundleSelection();
+        populateVersionOptions();
         renderFilteredBundles();
     });
 });
 
-async function loadBundles() {
+const toggleAllChangelogsAction = () => {
+    const cards = [...results.querySelectorAll(".bundle-item")];
+    allChangelogsExpanded = !allChangelogsExpanded;
+    for (const state of cardViewStates.values()) state.section = undefined;
+    cards.forEach(card => card.setActiveSection?.(
+        allChangelogsExpanded ? "changelog" : null,
+        false,
+        false
+    ));
+    updateAllChangelogsButton();
+};
+
+toggleAllChangelogs.addEventListener("click", toggleAllChangelogsAction);
+
+disabledSourcesToggle.addEventListener("click", () => {
+    showingDisabledSources = !showingDisabledSources;
+    disabledSourcesToggle.textContent = showingDisabledSources ? "Show bundles" : "Show disabled sources";
+    renderFilteredBundles();
+});
+
+viewToggle.addEventListener("click", () => {
+    const anchorBundleIndex = currentAnchorBundleIndex();
+    const gridEnabled = results.classList.toggle("grid-view");
+    container.classList.toggle("grid-view-enabled", gridEnabled);
+    viewToggle.setAttribute("aria-pressed", String(gridEnabled));
+    viewToggle.textContent = gridEnabled ? "List view" : "Grid view";
+    // Rebuild the row grouping while keeping the first visible bundle anchored.
+    setupVirtualizer(anchorBundleIndex);
+    updateStatus();
+});
+
+addEventListener("resize", () => {
+    const columns = layoutColumns();
+    if (columns !== lastColumns) setupVirtualizer(currentAnchorBundleIndex());
+});
+
+async function loadBundles(secret = null) {
     status.textContent = "Loading bundles...";
     status.classList.add("loading");
 
-    try {
-        const query = `
-            query Snapshot {
-                bundle(
-                  where: { is_latest: { _eq: true } }
-                  order_by: { source: { source_metadatum: { repo_stars: desc } } }
-                ) {
-                    id
-                    bundle_type
-                    created_at
-                    description
-                    download_url
-                    signature_download_url
-                    is_prerelease
-                    version
-                    source {
-                        url
-                        source_metadata: source_metadatum {
-                            owner_name
-                            owner_avatar_url
-                            repo_name
-                            repo_description
-                            repo_stars
-                            repo_pushed_at
-                            is_repo_archived
-                        }
-                    }
-                    patches {
-                        name
-                        description
-                        patch_packages {
-                            package {
-                                name
-                                version
-                            }
-                        }
-                    }
-                }
+    const query = `
+        query Snapshot {
+            bundle(
+              where: { is_latest: { _eq: true } }
+              order_by: { source: { source_metadatum: { repo_stars: desc } } }
+            ) {
+                ${BUNDLE_FIELDS}
             }
-        `;
-
-        const res = await fetch('/hasura/v1/graphql', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            query,
-          }),
-        });
-
-        if (!res.ok) {
-            status.textContent = "Failed to load bundles";
-            status.classList.remove("loading");
-            return;
+            ${secret ? `source {
+                    url
+                    enabled
+                    source_metadata: source_metadatum {
+                        owner_avatar_url
+                        repo_description
+                        repo_stars
+                        repo_pushed_at
+                    }
+                }` : ""}
         }
+    `;
 
-        const { data, errors } = await res.json();
-
-        if (errors) {
-            console.error('GraphQL errors:', errors);
-            status.textContent = "Failed to load bundles";
-            status.classList.remove("loading");
-            return;
-        }
-
+    try {
+        const data = await requestGraphQL(query, {}, secret);
         const bundles = data?.bundle || [];
+        disabledSources = secret
+            ? (data?.source || []).filter(source => !source.enabled).map(transformDisabledSource)
+            : [];
+        disabledSourcesToggle.hidden = !adminEnabled;
 
-        if (!Array.isArray(bundles) || bundles.length === 0) {
-            status.textContent = "No bundles available";
-            status.classList.remove("loading");
+        if (bundles.length === 0 && disabledSources.length === 0) {
+            latestBundles = [];
             allBundles = [];
+            filteredBundles = [];
+            clearVirtualizer();
+            status.textContent = "No bundles available";
             return;
         }
 
-        // Transform GraphQL data to match the old structure
-        allBundles = bundles.map(transformBundle);
-        status.classList.remove("loading");
+        latestBundles = bundles.map(transformBundle);
+        allBundles = latestBundles;
+        populateSourceOptions();
+        reconcileSourceSelection();
+        populateBundleTypeOptions();
         renderFilteredBundles();
-
-    } catch (e) {
-        console.error(e);
-        status.textContent = "Network error";
+    } catch (error) {
+        console.error(error);
+        status.textContent = "Failed to load bundles";
+    } finally {
         status.classList.remove("loading");
     }
+}
+
+async function requestGraphQL(query, variables = {}, secret = null) {
+    const headers = { 'Content-Type': 'application/json' };
+    if (secret) headers['X-Hasura-Admin-Secret'] = secret;
+    const response = await fetch('/hasura/v1/graphql', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ query, variables })
+    });
+
+    if (!response.ok) {
+        throw new Error(`GraphQL request failed with status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    if (payload.errors) {
+        throw new Error(payload.errors.map(error => error.message).join('; '));
+    }
+
+    return payload.data;
+}
+
+async function selectSource(sourceUrl) {
+    const requestId = ++sourceRequestId;
+    bundleRequestId++;
+    currentSourceUrl = sourceUrl;
+    sourceVersions = [];
+    resetBundleSelection();
+    setVersionControlsEnabled(false);
+    populateVersionOptions();
+    renderFilteredBundles();
+
+    if (!sourceUrl) return;
+
+    status.textContent = "Loading bundle versions...";
+    status.classList.add("loading");
+
+    const query = `
+        query SourceVersions($sourceUrl: String!) {
+            bundle(
+              where: { source: { url: { _eq: $sourceUrl } } }
+              order_by: { created_at: desc }
+            ) {
+                version
+                bundle_type
+                is_prerelease
+            }
+        }
+    `;
+
+    try {
+        const data = await requestGraphQL(query, { sourceUrl }, adminSecret);
+        if (requestId !== sourceRequestId) return;
+
+        sourceVersions = data?.bundle || [];
+        setVersionControlsEnabled(true);
+        populateVersionOptions();
+        populateBundleTypeOptions();
+        renderFilteredBundles();
+    } catch (error) {
+        if (requestId !== sourceRequestId) return;
+        console.error(error);
+        status.textContent = "Failed to load bundle versions";
+    } finally {
+        if (requestId === sourceRequestId) status.classList.remove("loading");
+    }
+}
+
+async function selectBundleVersion(version) {
+    const requestId = ++bundleRequestId;
+    currentBundleVersion = version;
+
+    if (!version) {
+        allBundles = latestBundles;
+        renderFilteredBundles();
+        return;
+    }
+
+    status.textContent = "Loading bundle...";
+    status.classList.add("loading");
+
+    const query = `
+        query BundleVersion($sourceUrl: String!, $version: String!) {
+            bundle(
+              where: {
+                source: { url: { _eq: $sourceUrl } }
+                version: { _eq: $version }
+              }
+              order_by: { created_at: desc }
+            ) {
+                ${BUNDLE_FIELDS}
+            }
+        }
+    `;
+
+    try {
+        const data = await requestGraphQL(query, {
+            sourceUrl: currentSourceUrl,
+            version
+        }, adminSecret);
+        if (requestId !== bundleRequestId) return;
+
+        allBundles = (data?.bundle || []).map(transformBundle);
+        renderFilteredBundles();
+    } catch (error) {
+        if (requestId !== bundleRequestId) return;
+        console.error(error);
+        status.textContent = "Failed to load bundle";
+    } finally {
+        if (requestId === bundleRequestId) status.classList.remove("loading");
+    }
+}
+
+function sourceOptionLabel(bundle) {
+    const parts = sourceName(bundle.sourceUrl, bundle.ownerName, bundle.repoName).split('/');
+    if (parts.length >= 2) {
+        return `${parts.slice(0, -1).join('/')} / ${parts[parts.length - 1]}`;
+    }
+    return parts[0];
+}
+
+function populateSourceOptions() {
+    const sources = new Map();
+    for (const bundle of latestBundles) {
+        if (!sources.has(bundle.sourceUrl)) {
+            let host = '';
+            try { host = new URL(bundle.sourceUrl).hostname; } catch { /* keep empty */ }
+            sources.set(bundle.sourceUrl, { base: sourceOptionLabel(bundle), host });
+        }
+    }
+
+    // A namespace/repo shared across hosts is ambiguous, so tag every option with that
+    // base with its host.
+    const baseHosts = new Map();
+    for (const { base, host } of sources.values()) {
+        const hosts = baseHosts.get(base) || new Set();
+        if (host) hosts.add(host);
+        baseHosts.set(base, hosts);
+    }
+
+    const options = [new Option("All sources", "")];
+    [...sources.entries()]
+        .sort((left, right) => left[1].base.localeCompare(right[1].base))
+        .forEach(([url, { base, host }]) => {
+            const label = baseHosts.get(base).size > 1 ? `${base} (${host})` : base;
+            options.push(new Option(label, url));
+        });
+    sourceFilter.replaceChildren(...options);
+}
+
+function reconcileSourceSelection() {
+    if (currentSourceUrl && !latestBundles.some(bundle => bundle.sourceUrl === currentSourceUrl)) {
+        sourceRequestId++;
+        currentSourceUrl = "";
+        sourceVersions = [];
+        resetBundleSelection();
+        setVersionControlsEnabled(false);
+        populateVersionOptions();
+    }
+    sourceFilter.value = currentSourceUrl;
+}
+
+function populateBundleTypeOptions() {
+    const selectedType = currentBundleType;
+    const types = new Set(latestBundles.map(bundle => bundle.bundleType).filter(Boolean));
+    sourceVersions.forEach(bundle => {
+        if (bundle.bundle_type) types.add(bundle.bundle_type);
+    });
+
+    const options = [new Option("All types", "")];
+    [...types].sort().forEach(type => options.push(new Option(type, type)));
+    bundleTypeFilter.replaceChildren(...options);
+    bundleTypeFilter.value = selectedType;
+}
+
+function populateVersionOptions() {
+    const options = [new Option("All versions", "")];
+    const versions = new Map();
+    sourceVersions
+        .filter(bundle => currentFilter === "all" || bundle.is_prerelease === (currentFilter === "prerelease"))
+        .filter(bundle => !currentBundleType || bundle.bundle_type === currentBundleType)
+        .forEach(bundle => {
+            if (!versions.has(bundle.version)) versions.set(bundle.version, bundle.is_prerelease);
+        });
+    versions.forEach((isPrerelease, version) => {
+        options.push(new Option(`${version} · ${isPrerelease ? "Prerelease" : "Release"}`, version));
+    });
+
+    bundleVersionFilter.replaceChildren(...options);
+    bundleVersionFilter.value = currentBundleVersion;
+}
+
+function setVersionControlsEnabled(enabled) {
+    bundleVersionFilter.disabled = !enabled;
+}
+
+function resetBundleSelection() {
+    bundleRequestId++;
+    currentBundleVersion = "";
+    bundleVersionFilter.value = "";
+    allBundles = latestBundles;
+}
+
+function installAvatarFallback(card, label) {
+    const image = card.querySelector(".owner-avatar");
+    if (!image) return;
+    const initial = escapeHtml(label.trim()[0] || "?").toUpperCase();
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect fill="#eee" width="100" height="100"/><text x="50" y="50" font-size="40" text-anchor="middle" dy=".3em" fill="#999">${initial}</text></svg>`;
+    image.addEventListener("error", () => {
+        image.src = `data:image/svg+xml,${encodeURIComponent(svg)}`;
+    }, { once: true });
+}
+
+function transformDisabledSource(source) {
+    const metadata = source.source_metadata || {};
+    return {
+        isDisabledSourceCard: true,
+        sourceUrl: source.url,
+        sourceName: sourceName(source.url, "", ""),
+        sourceEnabled: false,
+        ownerAvatarUrl: metadata.owner_avatar_url || "",
+        description: metadata.repo_description,
+        stars: metadata.repo_stars,
+        pushedAt: metadata.repo_pushed_at
+    };
 }
 
 function transformBundle(bundle) {
@@ -142,7 +681,9 @@ function transformBundle(bundle) {
         signatureDownloadUrl: bundle.signature_download_url,
         isPrerelease: bundle.is_prerelease,
         version: bundle.version,
-        sourceUrl: bundle.source?.url || '',
+         sourceUrl: bundle.source?.url || '',
+         sourceEnabled: bundle.source?.enabled ?? true,
+        sourceName: sourceName(bundle.source?.url, metadata.owner_name, metadata.repo_name),
         ownerName: metadata.owner_name || '',
         ownerAvatarUrl: metadata.owner_avatar_url || '',
         repoName: metadata.repo_name || '',
@@ -155,17 +696,35 @@ function transformBundle(bundle) {
 }
 
 function renderFilteredBundles() {
-    results.innerHTML = "";
+    if (showingDisabledSources) {
+        filteredBundles = disabledSources;
+        clearVirtualizer();
+        if (filteredBundles.length === 0) {
+            updateAllChangelogsButton();
+            status.textContent = "No disabled sources";
+            return;
+        }
+        document.scrollingElement.scrollTop = 0;
+        setupVirtualizer();
+        updateStatus();
+        return;
+    }
 
     if (allBundles.length === 0) {
+        filteredBundles = [];
+        clearVirtualizer();
+        updateAllChangelogsButton();
         status.textContent = "No bundles available";
         return;
     }
 
-    const filteredBundles = allBundles
+    filteredBundles = allBundles
         .map(bundle => {
             if (currentFilter === "release" && bundle.isPrerelease) return null;
             if (currentFilter === "prerelease" && !bundle.isPrerelease) return null;
+            if (currentSourceUrl && bundle.sourceUrl !== currentSourceUrl) return null;
+            if (currentBundleVersion && bundle.version !== currentBundleVersion) return null;
+            if (currentBundleType && bundle.bundleType !== currentBundleType) return null;
 
             if (currentSearchQuery) {
                 const searchableText = [
@@ -205,59 +764,120 @@ function renderFilteredBundles() {
         .filter(bundle => bundle !== null);
 
     if (filteredBundles.length === 0) {
+        clearVirtualizer();
+        updateAllChangelogsButton();
         const filterParts = [];
         if (currentSearchQuery) filterParts.push(`matching "${currentSearchQuery}"`);
         if (currentPackageFilter) filterParts.push(`for package "${currentPackageFilter}"`);
+        if (currentSourceUrl) filterParts.push(`from ${sourceFilter.selectedOptions[0]?.textContent}`);
+        if (currentBundleVersion) filterParts.push(`at ${currentBundleVersion}`);
+        if (currentBundleType) filterParts.push(`of type ${currentBundleType}`);
         if (currentFilter !== "all") filterParts.push(currentFilter);
 
         status.textContent = `No bundles found ${filterParts.join(' ')}`;
         return;
     }
 
-    status.textContent = "";
-    filteredBundles.forEach(renderBundle);
+    document.scrollingElement.scrollTop = 0;
+    setupVirtualizer();
+    updateStatus();
 }
 
-function renderBundle(bundle) {
-    const li = document.createElement("li");
-    li.className = "bundle-item";
 
-    const patchesPreview = bundle.patches.slice(0, 5);
-    const hasMore = bundle.patches.length > 5;
-    const v3WarningHtml = bundle.bundleType == "ReVanced:V3"
+function updateStatus() {
+    const count = filteredBundles.length;
+    if (count > 0) {
+        const noun = showingDisabledSources ? "source" : "bundle";
+        status.textContent = `Showing ${count} ${noun}${count === 1 ? "" : "s"}`;
+    }
+}
+
+function renderDisabledSource(source, target) {
+    const card = document.createElement("article");
+    card.className = "bundle-item disabled-source-card";
+    card.innerHTML = `
+        <div class="bundle-header">
+            <a href="${escapeHtml(source.sourceUrl)}" target="_blank" rel="noopener" class="owner-avatar-link" aria-label="Open ${escapeHtml(source.sourceName)} repository">
+                <img src="${escapeHtml(source.ownerAvatarUrl)}" alt="${escapeHtml(source.sourceName)}" class="owner-avatar" loading="lazy" decoding="async">
+            </a>
+            <div class="bundle-header-content">
+                <div class="repo-info">
+                    <a href="${escapeHtml(source.sourceUrl)}" target="_blank" rel="noopener" class="repo-name">
+                        ${escapeHtml(source.sourceName)}
+                    </a>
+                    <span>•</span>
+                    <span class="stars">${(source.stars || 0).toLocaleString()}</span>
+                </div>
+                ${source.description ? `<p class="repo-description">${escapeHtml(source.description)}</p>` : ''}
+                ${(() => { const d = formatDate(source.pushedAt); return d ? `<span class="created-date">Last updated ${d}</span>` : ''; })()}
+            </div>
+        </div>
+        <div class="admin-controls">
+            <button type="button" class="source-delete" data-source-delete
+                    aria-label="Hard-delete source" title="Hard-delete source">Hard-Delete</button>
+        </div>
+    `;
+    installAvatarFallback(card, source.sourceName);
+    target.appendChild(card);
+    card.querySelector("[data-source-delete]").addEventListener("click", () => deleteSource(source));
+}
+
+function renderBundle(bundle, target) {
+    const card = document.createElement("article");
+    card.className = "bundle-item";
+
+    const v3WarningHtml = bundle.bundleType === "ReVanced:V3"
         ? `<div class="v3-warning">
-                ⚠️ This bundle is V3. It will not be usable in URV and the patches list will always be empty.
+                ⚠️ It will not be usable in URV and the patches list can be empty.
            </div>`
         : '';
+    const tagUrl = releaseTagUrl(bundle);
+    const versionHtml = tagUrl
+        ? `<a class="version-text" href="${escapeHtml(tagUrl)}" target="_blank" rel="noopener">${escapeHtml(bundle.version)}</a>`
+        : `<span class="version-text">${escapeHtml(bundle.version)}</span>`;
 
-    li.innerHTML = `
+    // Show the tracked namespace/repo from the source URL; after an upstream rename the
+    // metadata names diverge from what is actually tracked, so both are shown.
+    const trackedParts = sourceName(bundle.sourceUrl, bundle.ownerName, bundle.repoName).split('/');
+    const trackedNamespace = trackedParts.length >= 2 ? trackedParts.slice(0, -1).join('/') : bundle.ownerName;
+    const trackedRepo = trackedParts.length >= 2 ? trackedParts[trackedParts.length - 1] : bundle.repoName;
+    const trackedName = `${trackedNamespace}/${trackedRepo}`;
+    const currentName = bundle.ownerName && bundle.repoName ? `${bundle.ownerName}/${bundle.repoName}` : '';
+    const repoLinkText = currentName && currentName !== trackedName
+        ? `${escapeHtml(trackedName)} <span class="renamed-name">(${escapeHtml(currentName)})</span>`
+        : escapeHtml(trackedName);
+
+    card.innerHTML = `
         ${v3WarningHtml}
 
         <div class="bundle-header">
-            <img src="${escapeHtml(bundle.ownerAvatarUrl)}"
-                 alt="${escapeHtml(bundle.ownerName)}"
-                 class="owner-avatar"
-                 onerror="this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Crect fill=%22%23eee%22 width=%22100%22 height=%22100%22/%3E%3Ctext x=%2250%22 y=%2250%22 font-size=%2240%22 text-anchor=%22middle%22 dy=%22.3em%22 fill=%22%23999%22%3E${escapeHtml(bundle.ownerName[0] || '?').toUpperCase()}%3C/text%3E%3C/svg%3E'">
+            <a href="${escapeHtml(bundle.sourceUrl)}" target="_blank" rel="noopener" class="owner-avatar-link" aria-label="Open ${escapeHtml(bundle.ownerName || 'source')} repository">
+                <img src="${escapeHtml(bundle.ownerAvatarUrl)}"
+                     alt="${escapeHtml(bundle.ownerName)}"
+                     class="owner-avatar"
+                     loading="lazy"
+                     decoding="async">
+            </a>
             <div class="bundle-header-content">
                 <div class="repo-info">
                     <a href="${escapeHtml(bundle.sourceUrl)}" target="_blank" rel="noopener" class="repo-name">
-                        ${escapeHtml(bundle.ownerName)}/${escapeHtml(bundle.repoName)}
+                        ${repoLinkText}
                     </a>
                     <span>•</span>
                     <span class="stars">${bundle.repoStars.toLocaleString()}</span>
                 </div>
-                ${bundle.repoDescription ? `<div class="bundle-description">${renderMarkdown(bundle.repoDescription)}</div>` : ''}
+                ${bundle.repoDescription ? `<div class="bundle-description">${cachedMarkdown(bundle.id, 'desc', bundle.repoDescription)}</div>` : ''}
                 <div class="bundle-version">
-                    <span class="version-text">${escapeHtml(bundle.version)}</span>
+                    ${versionHtml}
                     <span class="bundle-badge ${bundle.isPrerelease ? 'badge-prerelease' : 'badge-release'}">
                         ${bundle.isPrerelease ? 'Prerelease' : 'Release'}
                     </span>
+                    <span class="bundle-badge badge-type">${escapeHtml(bundle.bundleType)}</span>
+                    ${bundle.isRepoArchived ? `<span class="bundle-badge badge-archived">Archived</span>` : ''}
                     <span class="created-date">${formatDate(bundle.createdAt)}</span>
                 </div>
             </div>
         </div>
-
-        ${bundle.description ? `<div class="changelog-content">${renderMarkdown(bundle.description)}</div>` : ''}
 
         <div class="bundle-meta">
             <a href="${escapeHtml(bundle.downloadUrl)}" target="_blank" rel="noopener">
@@ -270,47 +890,35 @@ function renderBundle(bundle) {
                 </a>
             ` : ''}
             <span>•</span>
-            <button class="copy-btn" ${bundle.bundleType == "REVANCED_V3" ? 'disabled' : ''} data-url="https://revanced-external-bundles.brosssh.com/api/v1/bundle/${bundle.ownerName}/${bundle.repoName}/latest?prerelease=${bundle.isPrerelease}">
+            <button class="copy-btn" ${bundle.bundleType === "ReVanced:V3" ? 'disabled' : ''} data-url="/api/v3/bundle?source_url=${encodeURIComponent(bundle.sourceUrl)}&version=latest&channel=${bundle.isPrerelease ? 'prerelease' : 'stable'}">
                 Copy remote bundle URL
             </button>
         </div>
 
-        ${bundle.patches.length > 0 ? `
-                    <div class="patches-section">
-                        <div class="patches-header">
-                            <span class="patches-title">Patches</span>
-                            <span class="patches-count">${bundle.patches.length} total</span>
-                        </div>
-                        <div class="patches-list" data-patches-container>
-                            ${bundle.patches.map(patch => `
-                                <div class="patch-item">
-                                    <div class="patch-name">${escapeHtml(patch.name || 'Unnamed patch')}</div>
-                                    ${patch.description ? `<div class="patch-description">${escapeHtml(patch.description)}</div>` : ''}
-                                    ${patch.compatiblePackages && patch.compatiblePackages.length > 0 ? `
-                                        <div class="patch-packages">
-                                            ${patch.compatiblePackages.map(pkg => {
-                                                const versionsText = pkg.versions && pkg.versions.length > 0
-                                                    ? pkg.versions.filter(v => v).join(', ') || 'all versions'
-                                                    : 'all versions';
-                                                return `<span class="package-tag">
-                                                    <span class="package-name">${escapeHtml(pkg.name)}</span>
-                                                    <span class="package-versions">${escapeHtml(versionsText)}</span>
-                                                </span>`;
-                                            }).join('')}
-                                        </div>
-                                    ` : ''}
-                                </div>
-                            `).join('')}
-                </div>
+        ${(bundle.description || bundle.patches.length > 0) ? `
+            <div class="card-toggles">
+                ${bundle.description ? `
+                    <button class="card-toggle" type="button" data-toggle-changelog data-expanded="false">Show changelog</button>
+                ` : ''}
+                ${bundle.patches.length > 0 ? `
+                    <button class="card-toggle" type="button" data-toggle-patches data-expanded="false">Show patches (${bundle.patches.length})</button>
+                ` : ''}
+            </div>
+            <div class="card-content">
+                ${bundle.description ? `<div class="changelog-content" data-changelog hidden></div>` : ''}
+                ${bundle.patches.length > 0 ? `<div class="patches-content" data-patches-content hidden></div>` : ''}
             </div>
         ` : ''}
     `;
 
-    results.appendChild(li);
+    installAvatarFallback(card, bundle.ownerName || trackedName);
+    target.appendChild(card);
 
-    const copyBtn = li.querySelector(".copy-btn");
+    const copyBtn = card.querySelector(".copy-btn");
     copyBtn.addEventListener("click", async () => {
-        const url = copyBtn.dataset.url;
+        // The copied value must be absolute: it is pasted into the patched-app
+        // manager, which resolves it from the device, not from this page.
+        const url = new URL(copyBtn.dataset.url, location.origin).href;
         try {
             await navigator.clipboard.writeText(url);
             const originalText = copyBtn.textContent;
@@ -326,62 +934,158 @@ function renderBundle(bundle) {
         }
     });
 
-    const toggleBtn = li.querySelector("[data-toggle-patches]");
-    const patchesContainer = li.querySelector("[data-patches-container]");
+    const cardContent = card.querySelector(".card-content");
+    const changelogBtn = card.querySelector("[data-toggle-changelog]");
+    const changelogContainer = card.querySelector("[data-changelog]");
+    const patchesBtn = card.querySelector("[data-toggle-patches]");
+    const patchesContainer = card.querySelector("[data-patches-content]");
+    const viewState = cardViewStates.get(bundle.id) || {
+        section: undefined,
+        changelogScrollTop: 0,
+        patchesScrollTop: 0
+    };
 
-    if (toggleBtn && patchesContainer) {
-        let expanded = false;
+    const setActiveSection = (section, refreshGlobal = true, persist = true) => {
+        const showChangelog = section === "changelog";
+        const showPatches = section === "patches";
 
-        toggleBtn.addEventListener("click", () => {
-            if (!expanded) {
-                patchesContainer.innerHTML = bundle.patches.map(patch => `
-                    <div class="patch-item">
-                        <div class="patch-name">${escapeHtml(patch.name || 'Unnamed patch')}</div>
-                        ${patch.description ? `<div class="patch-description">${escapeHtml(patch.description)}</div>` : ''}
-                        ${patch.compatiblePackages && patch.compatiblePackages.length > 0 ? `
-                            <div class="patch-packages">
-                                ${patch.compatiblePackages.map(pkg => {
-                                    const versionsText = pkg.versions && pkg.versions.length > 0
-                                        ? pkg.versions.filter(v => v).join(', ') || 'all versions'
-                                        : 'all versions';
-                                    return `<span class="package-tag">
-                                        <span class="package-name">${escapeHtml(pkg.name)}</span>
-                                        <span class="package-versions">${escapeHtml(versionsText)}</span>
-                                    </span>`;
-                                }).join('')}
-                            </div>
-                        ` : ''}
-                    </div>
-                `).join('');
-                patchesContainer.classList.remove("collapsed");
-                toggleBtn.textContent = "Show less";
-                expanded = true;
-            } else {
-                patchesContainer.innerHTML = patchesPreview.map(patch => `
-                    <div class="patch-item">
-                        <div class="patch-name">${escapeHtml(patch.name || 'Unnamed patch')}</div>
-                        ${patch.description ? `<div class="patch-description">${escapeHtml(patch.description)}</div>` : ''}
-                        ${patch.compatiblePackages && patch.compatiblePackages.length > 0 ? `
-                            <div class="patch-packages">
-                                ${patch.compatiblePackages.map(pkg => {
-                                    const versionsText = pkg.versions && pkg.versions.length > 0
-                                        ? pkg.versions.filter(v => v).join(', ') || 'all versions'
-                                        : 'all versions';
-                                    return `<span class="package-tag">
-                                        <span class="package-name">${escapeHtml(pkg.name)}</span>
-                                        <span class="package-versions">${escapeHtml(versionsText)}</span>
-                                    </span>`;
-                                }).join('')}
-                            </div>
-                        ` : ''}
-                    </div>
-                `).join('');
-                patchesContainer.classList.add("collapsed");
-                toggleBtn.textContent = `Show all ${bundle.patches.length} patches`;
-                expanded = false;
+        if (changelogBtn && changelogContainer) {
+            changelogContainer.hidden = !showChangelog;
+            if (showChangelog && !changelogContainer.hasChildNodes()) {
+                changelogContainer.innerHTML = cachedMarkdown(bundle.id, 'changelog', bundle.description);
             }
-        });
+            if (showChangelog) restoreScrollTop(changelogContainer, viewState.changelogScrollTop);
+            changelogBtn.dataset.expanded = String(showChangelog);
+            changelogBtn.textContent = showChangelog ? "Hide changelog" : "Show changelog";
+        }
+
+        if (patchesBtn && patchesContainer) {
+            patchesContainer.hidden = !showPatches;
+            if (showPatches && !patchesContainer.hasChildNodes()) {
+                patchesContainer.innerHTML = cachedPatchList(bundle.patches);
+            }
+            if (showPatches) restoreScrollTop(patchesContainer, viewState.patchesScrollTop);
+            patchesBtn.dataset.expanded = String(showPatches);
+            patchesBtn.textContent = showPatches ? "Hide patches" : `Show patches (${bundle.patches.length})`;
+        }
+
+        if (cardContent) cardContent.classList.toggle("active", !!section);
+        if (persist) {
+            viewState.section = section;
+            cardViewStates.set(bundle.id, viewState);
+        }
+        // Row heights are re-measured automatically: virtualizer.measureElement
+        // registers each row with a ResizeObserver, so expanding a changelog or
+        // patch list corrects the virtual layout without a manual pass.
+        if (refreshGlobal) updateAllChangelogsButton();
+    };
+
+    card.setActiveSection = setActiveSection;
+    let initialSection = viewState.section;
+    if (initialSection === undefined) {
+        initialSection = allChangelogsExpanded && changelogBtn ? "changelog" : null;
     }
+    if (initialSection === "changelog" && !changelogBtn) initialSection = null;
+    if (initialSection === "patches" && !patchesBtn) initialSection = null;
+    setActiveSection(initialSection, false, false);
+
+    changelogContainer?.addEventListener("scroll", () => {
+        viewState.changelogScrollTop = changelogContainer.scrollTop;
+        cardViewStates.set(bundle.id, viewState);
+    }, { passive: true });
+    patchesContainer?.addEventListener("scroll", () => {
+        viewState.patchesScrollTop = patchesContainer.scrollTop;
+        cardViewStates.set(bundle.id, viewState);
+    }, { passive: true });
+
+    changelogBtn?.addEventListener("click", () => {
+        setActiveSection(changelogBtn.dataset.expanded === "true" ? null : "changelog");
+    });
+
+    patchesBtn?.addEventListener("click", () => {
+        setActiveSection(patchesBtn.dataset.expanded === "true" ? null : "patches");
+    });
+}
+
+async function deleteSource(bundle) {
+    if (!confirm(`Hard-delete ${bundle.sourceUrl} and all cached data? This cannot be undone.`)) return;
+    try {
+        const response = await fetch(`/api/v3/source?source_url=${encodeURIComponent(bundle.sourceUrl)}`, {
+            method: "DELETE",
+            headers: { "X-Hasura-Admin-Secret": adminSecret }
+        });
+        if (!response.ok) throw new Error(`Delete failed with status ${response.status}`);
+        await loadBundles(adminSecret);
+    } catch (error) {
+        console.error(error);
+        alert("Could not delete source.");
+    }
+}
+
+function updateAllChangelogsButton() {
+    toggleAllChangelogs.hidden = showingDisabledSources;
+    const hasChangelogs = !showingDisabledSources && filteredBundles.some(bundle => bundle.description);
+    toggleAllChangelogs.disabled = !hasChangelogs;
+    toggleAllChangelogs.textContent = allChangelogsExpanded ? "Hide all changelogs" : "Show all changelogs";
+}
+
+function renderPatch(patch) {
+    const packages = (patch.compatiblePackages || []).map(pkg => {
+        const versionsText = pkg.versions?.filter(Boolean).join(', ') || 'all versions';
+        return `<span class="package-tag">
+            <span class="package-name">${escapeHtml(pkg.name)}</span>
+            <span class="package-versions">${escapeHtml(versionsText)}</span>
+        </span>`;
+    }).join('');
+
+    return `<div class="patch-item">
+        <div class="patch-name">${escapeHtml(patch.name || 'Unnamed patch')}</div>
+        ${patch.description ? `<div class="patch-description">${escapeHtml(patch.description)}</div>` : ''}
+        ${packages ? `<div class="patch-packages">${packages}</div>` : ''}
+    </div>`;
+}
+
+function sourceName(sourceUrl, ownerName, repoName) {
+    try {
+        const path = new URL(sourceUrl).pathname.replace(/^\/+|\/+$/g, '');
+        return path || [ownerName, repoName].filter(Boolean).join('/');
+    } catch {
+        return [ownerName, repoName].filter(Boolean).join('/') || sourceUrl;
+    }
+}
+
+function releaseTagUrl(bundle) {
+    try {
+        const source = new URL(bundle.sourceUrl);
+        const repositoryUrl = `${source.origin}${source.pathname.replace(/\/+$/, '')}`;
+        const tag = encodeURIComponent(bundle.version);
+
+        if (source.hostname === 'gitlab.com') {
+            return `${repositoryUrl}/-/releases/${tag}`;
+        }
+        if (['github.com', 'codeberg.org', 'gitea.com'].includes(source.hostname)) {
+            return `${repositoryUrl}/releases/tag/${tag}`;
+        }
+
+        const download = new URL(bundle.downloadUrl);
+        const downloadPrefix = `${source.pathname.replace(/\/+$/, '')}/releases/download/`;
+        if (download.origin === source.origin && download.pathname.startsWith(downloadPrefix)) {
+            const downloadedTag = download.pathname.slice(downloadPrefix.length).split('/')[0];
+            if (downloadedTag) return `${repositoryUrl}/releases/tag/${downloadedTag}`;
+        }
+    } catch {
+        // Keep the version as plain text when the API URLs cannot identify a release page.
+    }
+
+    return null;
+}
+
+function debounce(callback, delay) {
+    let timeout;
+    return () => {
+        clearTimeout(timeout);
+        timeout = setTimeout(callback, delay);
+    };
 }
 
 function escapeHtml(text) {
@@ -392,16 +1096,14 @@ function escapeHtml(text) {
 
 function renderMarkdown(text) {
     if (!text) return '';
-    marked.setOptions({
-        breaks: true,
-        gfm: true
-    });
-    return marked.parse(text);
+    return DOMPurify.sanitize(marked.parse(text));
 }
 
 function formatDate(dateString) {
     try {
+        if (!dateString) return "";
         const date = new Date(dateString);
+        if (Number.isNaN(date.getTime())) return "";
         const now = new Date();
         const diffMs = now - date;
         const diffMins = Math.floor(diffMs / 60000);

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -4,36 +4,72 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Bundle Search</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:opsz,wght,ROND@6..144,1..1000,100&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="style.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/11.1.1/marked.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.4.14/purify.min.js"></script>
     </head>
     <body>
-    <div class="container">
-        <h1>Bundle Search</h1>
-        <p class="subtitle">Search for ReVanced patch bundles</p>
+    <div class="container grid-view-enabled">
+        <div class="page-header">
+            <div>
+                <h1>Bundle Search</h1>
+                <p class="subtitle">Search for ReVanced patch bundles</p>
+            </div>
+            <button id="admin-access" class="admin-access" type="button">Admin access</button>
+        </div>
         <div class="search-row">
             <input
                     type="text"
                     id="search"
+                    aria-label="Search bundles"
                     placeholder="Search bundles by source URL or name..."
                     autocomplete="off"
             >
             <input
                     type="text"
                     id="package-filter"
+                    aria-label="Filter by package"
                     placeholder="Filter by package (e.g., com.google.android.youtube)"
                     autocomplete="off"
             >
+        </div>
+        <div class="filter-row">
+            <label class="filter-field">
+                <span>Source</span>
+                <select id="source-filter">
+                    <option value="">All sources</option>
+                </select>
+            </label>
+            <label class="filter-field">
+                <span>Bundle version</span>
+                <select id="bundle-version-filter" disabled>
+                    <option value="">All versions</option>
+                </select>
+            </label>
+            <label class="filter-field">
+                <span>Bundle type</span>
+                <select id="bundle-type-filter">
+                    <option value="">All types</option>
+                </select>
+            </label>
         </div>
         <div class="filter-buttons">
             <button class="filter-btn" data-filter="all">All</button>
             <button class="filter-btn active" data-filter="release">Release</button>
             <button class="filter-btn" data-filter="prerelease">Prerelease</button>
+            <button id="disabled-sources-toggle" class="changelog-toggle" type="button" hidden>Show disabled sources</button>
+            <button id="toggle-all-changelogs" class="changelog-toggle" type="button" disabled>Show all changelogs</button>
+            <button id="view-toggle" class="view-toggle" type="button" aria-pressed="true">List view</button>
         </div>
         <div id="status">Loading bundles...</div>
-        <ul id="results"></ul>
+        <div id="results" class="grid-view">
+            <div class="v-track" id="v-track"></div>
+        </div>
     </div>
 
-    <script src="app.js"></script>
+    <script type="module" src="app.js"></script>
     </body>
     </html>

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -5,10 +5,24 @@
 }
 
 html, body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-family: "Google Sans Flex", system-ui, sans-serif;
     background-color: #f5f5f5;
     padding: 20px;
     min-height: 100vh;
+}
+
+button,
+input,
+select {
+    font-family: inherit;
+}
+
+select option {
+    font-family: inherit;
+}
+
+input::placeholder {
+    font-family: inherit;
 }
 
 .container {
@@ -17,9 +31,33 @@ html, body {
     background-color: transparent;
 }
 
+.page-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
+
 h1 {
     margin-bottom: 8px;
     color: #333;
+}
+
+.admin-access {
+    flex-shrink: 0;
+    padding: 8px 12px;
+    border: 2px solid #ddd;
+    border-radius: 6px;
+    background: white;
+    color: #666;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.admin-access:hover {
+    border-color: #1976d2;
+    color: #1976d2;
 }
 
 .subtitle {
@@ -49,13 +87,56 @@ h1 {
     border-color: #4CAF50;
 }
 
+.filter-row {
+    display: grid;
+    grid-template-columns: 1.2fr 1.8fr 1fr;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.filter-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    color: #555;
+    font-size: 13px;
+    font-weight: 500;
+}
+
+.filter-field select,
+.filter-field input {
+    width: 100%;
+    min-width: 0;
+    padding: 10px 12px;
+    border: 2px solid #ddd;
+    border-radius: 6px;
+    background: white;
+    color: #333;
+    font-size: 14px;
+}
+
+.filter-field select:focus,
+.filter-field input:focus {
+    outline: none;
+    border-color: #4CAF50;
+}
+
+.filter-field select:disabled,
+.filter-field input:disabled {
+    background: #eee;
+    color: #999;
+    cursor: not-allowed;
+}
+
 .filter-buttons {
     display: flex;
     gap: 8px;
     margin-bottom: 20px;
 }
 
-.filter-btn {
+.filter-btn,
+.changelog-toggle,
+.view-toggle {
     padding: 8px 16px;
     font-size: 14px;
     border: 2px solid #ddd;
@@ -67,9 +148,29 @@ h1 {
     font-weight: 500;
 }
 
-.filter-btn:hover {
+.filter-btn:hover,
+.changelog-toggle:hover,
+.view-toggle:hover {
     border-color: #4CAF50;
     color: #4CAF50;
+}
+
+.changelog-toggle {
+    margin-left: auto;
+}
+
+#disabled-sources-toggle:not([hidden]) {
+    margin-left: auto;
+}
+
+#disabled-sources-toggle:not([hidden]) + #toggle-all-changelogs {
+    margin-left: 0;
+}
+
+.changelog-toggle:disabled {
+    border-color: #ddd;
+    color: #999;
+    cursor: not-allowed;
 }
 
 .filter-btn.active {
@@ -96,11 +197,44 @@ h1 {
     60%, 100% { content: "..."; }
 }
 
+.container.grid-view-enabled {
+    max-width: 1400px;
+}
+
 #results {
-    list-style: none;
+    position: relative;
+    margin: 0;
+    padding: 0;
+}
+
+.v-track {
+    position: relative;
+}
+
+.virtual-row {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    display: grid;
+    gap: 16px;
+    align-items: stretch;
+    will-change: transform;
+}
+
+#results.grid-view .virtual-row {
+    grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+}
+
+#results .virtual-row .bundle-item {
+    height: 100%;
+    margin-bottom: 0;
 }
 
 .bundle-item {
+    display: flex;
+    flex-direction: column;
+    max-height: 600px;
     background: white;
     border-radius: 8px;
     padding: 20px;
@@ -114,12 +248,23 @@ h1 {
     margin-bottom: 12px;
 }
 
+.owner-avatar-link {
+    display: block;
+    flex-shrink: 0;
+    border-radius: 50%;
+}
+
+.owner-avatar-link:focus-visible {
+    outline: 2px solid #1976d2;
+    outline-offset: 2px;
+}
+
 .owner-avatar {
+    display: block;
     width: 48px;
     height: 48px;
     border-radius: 50%;
     border: 2px solid #eee;
-    flex-shrink: 0;
 }
 
 .bundle-header-content {
@@ -142,6 +287,12 @@ h1 {
     font-weight: 500;
 }
 
+.renamed-name {
+    color: #999;
+    font-weight: 400;
+    font-size: 12px;
+}
+
 .repo-name:hover {
     text-decoration: underline;
 }
@@ -158,15 +309,20 @@ h1 {
 
 .bundle-version {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 8px;
     margin-bottom: 4px;
 }
 
 .version-text {
+    color: #333;
     font-size: 18px;
     font-weight: 600;
-    color: #333;
+}
+
+a.version-text:hover {
+    color: #1976d2;
 }
 
 .bundle-badge {
@@ -185,6 +341,16 @@ h1 {
 .badge-prerelease {
     background: #fff3e0;
     color: #f57c00;
+}
+
+.badge-type {
+    background: #f3e5f5;
+    color: #7b1fa2;
+}
+
+.badge-archived {
+    background: #eceff1;
+    color: #607d8b;
 }
 
 .created-date {
@@ -255,17 +421,12 @@ h1 {
 }
 
 .changelog-content {
-    max-height: 200px;
-    overflow-y: auto;
-    padding: 12px;
+    padding: 12px 12px 12px 20px;
     background: #f9f9f9;
     border-radius: 6px;
     font-size: 14px;
     line-height: 1.5;
     color: #666;
-    padding-left: 20px;
-    padding-right: 12px;
-    margin-bottom: 12px;
 }
 
 .changelog-content p {
@@ -299,22 +460,91 @@ h1 {
     overflow-x: auto;
 }
 
-.changelog-content::-webkit-scrollbar {
+.changelog-content::-webkit-scrollbar,
+.patches-content::-webkit-scrollbar {
     width: 6px;
 }
 
-.changelog-content::-webkit-scrollbar-track {
+.changelog-content::-webkit-scrollbar-track,
+.patches-content::-webkit-scrollbar-track {
     background: #f1f1f1;
     border-radius: 3px;
 }
 
-.changelog-content::-webkit-scrollbar-thumb {
+.changelog-content::-webkit-scrollbar-thumb,
+.patches-content::-webkit-scrollbar-thumb {
     background: #ccc;
     border-radius: 3px;
 }
 
-.changelog-content::-webkit-scrollbar-thumb:hover {
+.changelog-content::-webkit-scrollbar-thumb:hover,
+.patches-content::-webkit-scrollbar-thumb:hover {
     background: #999;
+}
+
+.card-toggles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.card-toggle {
+    padding: 6px 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: #fafafa;
+    color: #555;
+    cursor: pointer;
+    font-size: 13px;
+}
+
+.card-toggle:hover {
+    border-color: #4CAF50;
+    color: #388E3C;
+}
+
+.card-content {
+    display: none;
+}
+
+.card-content.active {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+
+.changelog-content,
+.patches-content {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 8px;
+}
+
+.admin-controls {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.disabled-source-card .admin-controls {
+    flex: 1;
+    align-items: flex-end;
+    margin-bottom: 0;
+}
+
+.source-delete {
+    height: 32px;
+    padding: 6px 12px;
+    border: 0;
+    border-radius: 4px;
+    background: #dc2626;
+    color: white;
+    cursor: pointer;
+    font-size: 13px;
+    line-height: 1;
 }
 
 .bundle-meta {
@@ -360,42 +590,10 @@ h1 {
     opacity: 0.6;
 }
 
-.patches-section {
-    margin-top: 16px;
-    padding-top: 16px;
-    border-top: 1px solid #eee;
-}
-
-.patches-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 12px;
-}
-
-.patches-title {
-    font-weight: 600;
-    color: #333;
-    font-size: 14px;
-}
-
-.patches-count {
-    color: #666;
-    font-size: 13px;
-}
-
 .patches-list {
     display: grid;
     gap: 8px;
-    max-height: 120px;     /* collapsed height */
-    overflow-y: auto;      /* allow scrolling */
-    padding-right: 8px;
-    transition: max-height 0.3s ease;
-}
-
-.patches-list.collapsed {
-    max-height: 120px;
-    overflow: hidden;
+    padding-right: 4px;
 }
 
 .patch-item {
@@ -446,20 +644,6 @@ h1 {
     font-size: 10px;
 }
 
-.toggle-patches {
-    background: none;
-    border: none;
-    color: #1976d2;
-    cursor: pointer;
-    font-size: 13px;
-    padding: 4px 0;
-    margin-top: 8px;
-}
-
-.toggle-patches:hover {
-    text-decoration: underline;
-}
-
 .patches-list::-webkit-scrollbar {
     width: 6px;
 }
@@ -476,4 +660,165 @@ h1 {
 
 .patches-list::-webkit-scrollbar-thumb:hover {
     background: #999;
+}
+
+@media (max-width: 700px) {
+    .page-header {
+        align-items: center;
+    }
+
+    .admin-access {
+        padding: 7px 10px;
+        font-size: 13px;
+    }
+
+    html, body {
+        padding: 12px;
+        overflow-x: hidden;
+    }
+
+    h1 {
+        font-size: 1.75rem;
+    }
+
+    .subtitle {
+        margin-bottom: 16px;
+    }
+
+    .search-row,
+    .filter-row {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+
+    .search-row {
+        margin-bottom: 14px;
+    }
+
+    .filter-row {
+        margin-bottom: 12px;
+    }
+
+    .filter-buttons {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+        margin-bottom: 14px;
+    }
+
+    .filter-btn,
+    .changelog-toggle,
+    .view-toggle {
+        width: 100%;
+        min-height: 44px;
+        padding: 8px 10px;
+    }
+
+    .changelog-toggle,
+    .view-toggle {
+        grid-column: 1 / -1;
+        margin-left: 0;
+    }
+
+    .bundle-item {
+        max-height: min(600px, calc(100vh - 24px));
+        padding: 14px;
+        border-radius: 10px;
+        margin-bottom: 10px;
+    }
+
+    .bundle-header {
+        align-items: flex-start;
+        gap: 10px;
+        margin-bottom: 10px;
+    }
+
+    .owner-avatar {
+        width: 40px;
+        height: 40px;
+    }
+
+    .repo-info {
+        align-items: flex-start;
+        flex-wrap: wrap;
+        gap: 4px 8px;
+        line-height: 1.35;
+    }
+
+    .repo-name {
+        overflow-wrap: anywhere;
+    }
+
+    .renamed-name {
+        display: block;
+        flex-basis: 100%;
+        overflow-wrap: anywhere;
+    }
+
+    .bundle-version {
+        gap: 6px;
+    }
+
+    .version-text {
+        font-size: 16px;
+        overflow-wrap: anywhere;
+    }
+
+    .bundle-badge {
+        padding: 4px 9px;
+    }
+
+    .bundle-meta {
+        gap: 8px;
+        line-height: 1.35;
+    }
+
+    .v3-warning {
+        align-items: flex-start;
+        padding: 10px;
+        font-size: 13px;
+    }
+
+    .bundle-meta .copy-btn {
+        width: 100%;
+        min-height: 40px;
+    }
+
+    .card-toggles {
+        margin-bottom: 10px;
+    }
+
+    .card-toggle {
+        flex: 1 1 140px;
+        min-height: 40px;
+        padding: 7px 8px;
+    }
+
+    .bundle-description,
+    .changelog-content {
+        font-size: 13px;
+    }
+}
+
+@media (max-width: 420px) {
+    html, body {
+        padding: 8px;
+    }
+
+    .filter-field select,
+    .filter-field input,
+    #search,
+    #package-filter {
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+
+    .filter-field select {
+        text-overflow: ellipsis;
+    }
+
+    .bundle-badge {
+        padding: 4px 8px;
+        font-size: 11px;
+    }
 }

--- a/src/test/kotlin/me/brosssh/bundles/api/v3/routes/SourceRoutesTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/api/v3/routes/SourceRoutesTest.kt
@@ -1,0 +1,126 @@
+package me.brosssh.bundles.api.v3.routes
+
+import io.ktor.client.request.delete
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import me.brosssh.bundles.domain.models.SourceDeletionResult
+import me.brosssh.bundles.plugins.configureSerialization
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SourceRoutesTest {
+    @Test
+    fun `missing or invalid admin secret is rejected before deletion`() = testApplication {
+        var invoked = false
+        application {
+            configureSerialization()
+            routing {
+                route("/api/v3") {
+                    sourceRoutes(ADMIN_SECRET) {
+                        invoked = true
+                        SourceDeletionResult.NotFound
+                    }
+                }
+            }
+        }
+
+        val missing = client.delete("/api/v3/source") {
+            parameter("source_url", SOURCE_URL)
+        }
+        val invalid = client.delete("/api/v3/source") {
+            parameter("source_url", SOURCE_URL)
+            header(HASURA_ADMIN_SECRET_HEADER, "invalid")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, missing.status)
+        assertEquals(HttpStatusCode.Unauthorized, invalid.status)
+        assertFalse(invoked)
+    }
+
+    @Test
+    fun `valid admin secret deletes the canonical source and reports counts`() = testApplication {
+        var deletedSourceUrl: String? = null
+        application {
+            configureSerialization()
+            routing {
+                route("/api/v3") {
+                    sourceRoutes(ADMIN_SECRET) { sourceUrl ->
+                        deletedSourceUrl = sourceUrl
+                        SourceDeletionResult.Deleted(sources = 1, bundles = 3, patches = 7)
+                    }
+                }
+            }
+        }
+
+        val response = client.delete("/api/v3/source") {
+            parameter("source_url", "$SOURCE_URL/")
+            header(HASURA_ADMIN_SECRET_HEADER, ADMIN_SECRET)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(SOURCE_URL, deletedSourceUrl)
+        assertEquals(
+            """{"deleted_sources":1,"deleted_bundles":3,"deleted_patches":7}""",
+            response.bodyAsText()
+        )
+    }
+
+    @Test
+    fun `enabled source is rejected`() = testApplication {
+        var invoked = false
+        application {
+            configureSerialization()
+            routing {
+                route("/api/v3") {
+                    sourceRoutes(ADMIN_SECRET) {
+                        invoked = true
+                        SourceDeletionResult.Enabled
+                    }
+                }
+            }
+        }
+
+        val response = client.delete("/api/v3/source") {
+            parameter("source_url", SOURCE_URL)
+            header(HASURA_ADMIN_SECRET_HEADER, ADMIN_SECRET)
+        }
+
+        assertEquals(HttpStatusCode.Conflict, response.status)
+        assertTrue(invoked)
+    }
+
+    @Test
+    fun `missing source URL is rejected before deletion`() = testApplication {
+        var invoked = false
+        application {
+            configureSerialization()
+            routing {
+                route("/api/v3") {
+                    sourceRoutes(ADMIN_SECRET) {
+                        invoked = true
+                        SourceDeletionResult.NotFound
+                    }
+                }
+            }
+        }
+
+        val response = client.delete("/api/v3/source") {
+            header(HASURA_ADMIN_SECRET_HEADER, ADMIN_SECRET)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertFalse(invoked)
+    }
+
+    private companion object {
+        const val ADMIN_SECRET = "hasura-admin-secret"
+        const val SOURCE_URL = "https://github.com/example/patches"
+    }
+}

--- a/src/test/kotlin/me/brosssh/bundles/db/HasuraMetadataTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/db/HasuraMetadataTest.kt
@@ -1,0 +1,66 @@
+package me.brosssh.bundles.db
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HasuraMetadataTest {
+    private val tables: JsonArray by lazy {
+        val metadata = requireNotNull(javaClass.getResourceAsStream("/hasura/metadata.json"))
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+        metadata["metadata"]!!.jsonObject["sources"]!!.jsonArray
+            .single().jsonObject["tables"]!!.jsonArray
+    }
+
+    @Test
+    fun `public bundle and patch data requires an enabled source`() {
+        assertEquals(enabledSourceFilter(), userFilter("bundle"))
+        assertEquals(
+            buildJsonObject { put("bundle", enabledSourceFilter()) },
+            userFilter("patch")
+        )
+        assertEquals(
+            buildJsonObject {
+                put("patch", buildJsonObject { put("bundle", enabledSourceFilter()) })
+            },
+            userFilter("patch_package")
+        )
+    }
+
+    @Test
+    fun `public source list includes enabled state without filtering disabled sources`() {
+        val permission = userPermission("source")
+        val columns = permission["columns"]!!.jsonArray.map { it.jsonPrimitive.content }
+
+        assertTrue("enabled" in columns)
+        assertEquals(JsonObject(emptyMap()), permission["filter"])
+    }
+
+    private fun enabledSourceFilter() = buildJsonObject {
+        put("source", buildJsonObject {
+            put("enabled", buildJsonObject {
+                put("_eq", JsonPrimitive(true))
+            })
+        })
+    }
+
+    private fun userFilter(tableName: String) = userPermission(tableName)["filter"]!!.jsonObject
+
+    private fun userPermission(tableName: String): JsonObject {
+        val table = tables.single {
+            it.jsonObject["table"]!!.jsonObject["name"]!!.jsonPrimitive.content == tableName
+        }.jsonObject
+        return table["select_permissions"]!!.jsonArray.single {
+            it.jsonObject["role"]!!.jsonPrimitive.content == "user"
+        }.jsonObject["permission"]!!.jsonObject
+    }
+}

--- a/src/test/kotlin/me/brosssh/bundles/repositories/DisabledSourceRepositoryTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/repositories/DisabledSourceRepositoryTest.kt
@@ -1,0 +1,177 @@
+package me.brosssh.bundles.repositories
+
+import me.brosssh.bundles.db.tables.BundleTable
+import me.brosssh.bundles.db.tables.PackageTable
+import me.brosssh.bundles.db.tables.PatchPackageTable
+import me.brosssh.bundles.db.tables.PatchTable
+import me.brosssh.bundles.db.tables.SourceMetadataTable
+import me.brosssh.bundles.db.tables.SourceTable
+import me.brosssh.bundles.domain.models.BundleType
+import me.brosssh.bundles.domain.models.ReleaseChannel
+import me.brosssh.bundles.domain.models.SourceDeletionResult
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class DisabledSourceRepositoryTest {
+    private lateinit var database: Database
+
+    @BeforeTest
+    fun setUp() {
+        database = Database.connect(
+            url = "jdbc:h2:mem:${UUID.randomUUID()};MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+            driver = "org.h2.Driver"
+        )
+        TransactionManager.defaultDatabase = database
+        transaction(database) {
+            SchemaUtils.create(
+                SourceTable,
+                SourceMetadataTable,
+                BundleTable,
+                PatchTable,
+                PackageTable,
+                PatchPackageTable
+            )
+        }
+    }
+
+    @Test
+    fun `legacy lookups hide disabled bundles while explicit source lookups retain access`() {
+        val fixture = insertSource(enabled = false)
+        val repository = BundleRepository()
+
+        assertNull(repository.findById(fixture.bundleId))
+        assertNull(repository.findLatestByRepo(OWNER, REPO, prerelease = false))
+        assertNull(repository.findByRepoAndVersion(OWNER, REPO, VERSION))
+        assertNull(repository.findByRepoAndChannel(OWNER, REPO, ReleaseChannel.STABLE))
+        assertTrue(repository.getBundlesNeedPatchesUpdate().isEmpty())
+
+        assertNotNull(repository.findBySourceAndChannel(SOURCE_URL, ReleaseChannel.STABLE))
+        assertNotNull(repository.findBySourceAndVersion(SOURCE_URL, VERSION, ReleaseChannel.STABLE))
+
+        transaction(database) {
+            SourceTable.update({ SourceTable.id eq fixture.sourceId }) {
+                it[enabled] = true
+            }
+        }
+
+        assertNotNull(repository.findById(fixture.bundleId))
+        assertNotNull(repository.findLatestByRepo(OWNER, REPO, prerelease = false))
+        assertNotNull(repository.findByRepoAndVersion(OWNER, REPO, VERSION))
+        assertNotNull(repository.findByRepoAndChannel(OWNER, REPO, ReleaseChannel.STABLE))
+        assertEquals(1, repository.getBundlesNeedPatchesUpdate().size)
+    }
+
+    @Test
+    fun `hard deletion removes a disabled source and its owned rows`() {
+        insertSource(enabled = false, patchCount = 2)
+
+        val result = assertIs<SourceDeletionResult.Deleted>(
+            SourceRepository().hardDelete(SOURCE_URL)
+        )
+
+        assertEquals(1, result.sources)
+        assertEquals(1, result.bundles)
+        assertEquals(2, result.patches)
+        transaction(database) {
+            assertEquals(0, SourceTable.selectAll().count())
+            assertEquals(0, SourceMetadataTable.selectAll().count())
+            assertEquals(0, BundleTable.selectAll().count())
+            assertEquals(0, PatchTable.selectAll().count())
+            assertEquals(0, PatchPackageTable.selectAll().count())
+            assertEquals(1, PackageTable.selectAll().count())
+        }
+    }
+
+    @Test
+    fun `hard deletion rejects an enabled source without changing it`() {
+        insertSource(enabled = true)
+
+        assertSame(SourceDeletionResult.Enabled, SourceRepository().hardDelete(SOURCE_URL))
+
+        transaction(database) {
+            assertEquals(1, SourceTable.selectAll().count())
+            assertEquals(1, SourceMetadataTable.selectAll().count())
+            assertEquals(1, BundleTable.selectAll().count())
+        }
+    }
+
+    @Test
+    fun `hard deletion reports an unknown source`() {
+        assertSame(SourceDeletionResult.NotFound, SourceRepository().hardDelete(SOURCE_URL))
+    }
+
+    private fun insertSource(enabled: Boolean, patchCount: Int = 1): Fixture = transaction(database) {
+        val sourceId = SourceTable.insertAndGetId {
+            it[url] = SOURCE_URL
+            it[SourceTable.enabled] = enabled
+        }
+        SourceMetadataTable.insert {
+            it[sourceFk] = sourceId
+            it[ownerName] = OWNER
+            it[ownerAvatarUrl] = "https://example.com/avatar.png"
+            it[repoName] = REPO
+            it[repoDescription] = null
+            it[repoStars] = 1
+            it[isRepoArchived] = false
+            it[repoPushedAt] = "2026-03-25T00:00:00Z"
+        }
+        val bundleId = BundleTable.insertAndGetId {
+            it[version] = VERSION
+            it[createdAt] = "2026-03-25T00:00:00Z"
+            it[description] = null
+            it[downloadUrl] = "https://example.com/bundle.rvp"
+            it[signatureDownloadUrl] = null
+            it[isPrerelease] = false
+            it[isLatest] = true
+            it[fileHash] = null
+            it[needPatchesUpdate] = true
+            it[bundleType] = BundleType.REVANCED_V4.value
+            it[sourceFk] = sourceId
+        }
+        val packageId = PackageTable.insertAndGetId {
+            it[name] = "com.example.app"
+            it[version] = null
+        }
+        repeat(patchCount) { index ->
+            val patchId = PatchTable.insertAndGetId {
+                it[bundleFk] = bundleId
+                it[name] = "Patch $index"
+                it[description] = null
+            }
+            PatchPackageTable.insert {
+                it[patchFk] = patchId
+                it[packageFk] = packageId
+            }
+        }
+
+        Fixture(sourceId.value, bundleId.value)
+    }
+
+    private data class Fixture(
+        val sourceId: Int,
+        val bundleId: Int
+    )
+
+    private companion object {
+        const val SOURCE_URL = "https://github.com/example/patches"
+        const val OWNER = "example"
+        const val REPO = "patches"
+        const val VERSION = "v1.0.0"
+    }
+}


### PR DESCRIPTION
## Changes

The bundle browser on the public site got a rework. The list used to render every bundle up front and it showed while scrolling, so it's now virtualized with TanStack Virtual: only the rows you can see are in the DOM, in both grid and list layouts.

Cards look different too. Changelog and patches live behind toggles, the badges cover bundle type and release/prerelease/archived state, the version tag links to the actual release page on the git host, renamed repos show both names, and the avatar is clickable and comes from our source metadata instead of a guessed host URL.

There is now an admin mode: enter the Hasura admin secret and you get a disabled-sources view, where a source can be hard-deleted through the v3 API. The configure note in `.env.example` warns that an empty secret makes admin auth behave inconsistently.

Also switched the copy-URL button to the v3 endpoint, disambiguated same-named sources across hosts in the dropdown, and moved the site font to Google Sans Flex.

Depends on #44.

## Testing

- Admin flow (disabled-sources view, hard-delete) and scrolling exercised in a browser.