### PR TITLE
feat(workers): defer unavailable git host work

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.ktor.test.host)
+    testImplementation(libs.ktor.client.mock)
     testRuntimeOnly(libs.h2)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp-jvm", version.ref = 
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation-jvm", version.ref = "ktor" }
 ktor-client-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json-jvm", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock-jvm", version.ref = "ktor" }
 
 # Ktor OpenAPI tools
 ktor-swagger-ui = { module = "io.github.smiley4:ktor-swagger-ui", version.ref = "openapi-tools" }

--- a/src/main/kotlin/me/brosssh/bundles/db/entities/SourceEntity.kt
+++ b/src/main/kotlin/me/brosssh/bundles/db/entities/SourceEntity.kt
@@ -1,6 +1,5 @@
 package me.brosssh.bundles.db.entities
 
-import me.brosssh.bundles.db.tables.SourceMetadataTable
 import me.brosssh.bundles.db.tables.SourceTable
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.dao.IntEntity
@@ -11,4 +10,5 @@ class SourceEntity(id: EntityID<Int>) : IntEntity(id) {
 
     var url by SourceTable.url
     var enabled by SourceTable.enabled
+    var unavailableReason by SourceTable.unavailableReason
 }

--- a/src/main/kotlin/me/brosssh/bundles/db/migration/MigrationDSL.kt
+++ b/src/main/kotlin/me/brosssh/bundles/db/migration/MigrationDSL.kt
@@ -80,6 +80,20 @@ fun migrationScript() {
         """)
 
         exec("""
+            ALTER TABLE source
+            ADD COLUMN IF NOT EXISTS unavailable_reason TEXT;
+        """)
+
+        exec("""
+            CREATE TABLE IF NOT EXISTS git_host_rate_limit (
+                authority VARCHAR(255) NOT NULL,
+                credential_fingerprint VARCHAR(64) NOT NULL,
+                rate_limited_until TIMESTAMPTZ NOT NULL,
+                PRIMARY KEY (authority, credential_fingerprint)
+            );
+        """)
+
+        exec("""
             ALTER TABLE bundle
             ADD COLUMN IF NOT EXISTS patcher_runtime VARCHAR(255);
         """)

--- a/src/main/kotlin/me/brosssh/bundles/db/tables/GitHostRateLimitTable.kt
+++ b/src/main/kotlin/me/brosssh/bundles/db/tables/GitHostRateLimitTable.kt
@@ -1,0 +1,12 @@
+package me.brosssh.bundles.db.tables
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
+
+object GitHostRateLimitTable : Table("git_host_rate_limit") {
+    val authority = varchar("authority", 255)
+    val credentialFingerprint = varchar("credential_fingerprint", 64)
+    val rateLimitedUntil = timestampWithTimeZone("rate_limited_until")
+
+    override val primaryKey = PrimaryKey(authority, credentialFingerprint)
+}

--- a/src/main/kotlin/me/brosssh/bundles/db/tables/SourceTable.kt
+++ b/src/main/kotlin/me/brosssh/bundles/db/tables/SourceTable.kt
@@ -5,4 +5,5 @@ import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 object SourceTable : IntIdTable("source") {
     val url = varchar("url", 255)
     val enabled = bool("enabled").default(true)
+    val unavailableReason = text("unavailable_reason").nullable()
 }

--- a/src/main/kotlin/me/brosssh/bundles/di/AppModule.kt
+++ b/src/main/kotlin/me/brosssh/bundles/di/AppModule.kt
@@ -31,6 +31,7 @@ val appModule = module {
     single { RefreshJobRepository() }
     single { PackageRepository() }
     single { PatchPackageRepository() }
+    single { GitHostRateLimitRepository() }
 
     single(createdAtStart = true) {
         PatchWorkerManager(
@@ -64,6 +65,8 @@ val appModule = module {
 
     single {
         RefreshBundlesJobService(
+            get(),
+            get(),
             get(),
             get(),
             get(),

--- a/src/main/kotlin/me/brosssh/bundles/domain/services/jobs/RefreshBundlesJobService.kt
+++ b/src/main/kotlin/me/brosssh/bundles/domain/services/jobs/RefreshBundlesJobService.kt
@@ -1,11 +1,18 @@
 package me.brosssh.bundles.domain.services.jobs
 
+import io.ktor.client.plugins.ClientRequestException
+import kotlinx.coroutines.CancellationException
+import me.brosssh.bundles.db.entities.SourceEntity
 import me.brosssh.bundles.db.functions.refreshIsLatestFlag
 import me.brosssh.bundles.domain.models.BundleImportError
 import me.brosssh.bundles.domain.models.RefreshJob
 import me.brosssh.bundles.integrations.HostResolver
+import me.brosssh.bundles.integrations.common.GitHostClient
+import me.brosssh.bundles.integrations.common.GitHostCredentials
+import me.brosssh.bundles.integrations.common.sourceUnavailableReason
 import me.brosssh.bundles.integrations.common.toDomainModel
 import me.brosssh.bundles.repositories.BundleRepository
+import me.brosssh.bundles.repositories.GitHostRateLimitRepository
 import me.brosssh.bundles.repositories.RefreshJobRepository
 import me.brosssh.bundles.repositories.SourceMetadataRepository
 import me.brosssh.bundles.repositories.SourceRepository
@@ -13,13 +20,17 @@ import me.brosssh.bundles.util.intId
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 class RefreshBundlesJobService(
     refreshJobRepository: RefreshJobRepository,
     private val hostResolver: HostResolver,
     private val sourceRepository: SourceRepository,
     private val sourceMetadataRepository: SourceMetadataRepository,
-    private val bundleRepository: BundleRepository
+    private val bundleRepository: BundleRepository,
+    private val credentials: GitHostCredentials,
+    private val rateLimitRepository: GitHostRateLimitRepository
 ) : BaseRefreshJobService(refreshJobRepository) {
 
     override val logger: Logger = LoggerFactory.getLogger(RefreshBundlesJobService::class.java)
@@ -31,31 +42,13 @@ class RefreshBundlesJobService(
         sourceRepository.getEnabled().forEach { source ->
             logger.info("Processing source ${source.url}")
             try {
-                suspendTransaction {
-                    val resolved = hostResolver.resolve(source.url)
-
-                    // Update metatable
-                    sourceMetadataRepository.upsert(
-                        resolved.client.getRepo(resolved.ref).toDomainModel(source.intId)
-                    )
-
-                    // Update bundle table
-                    resolved.client.getReleases(resolved.ref).forEach { release ->
-                        try {
-                            bundleRepository.upsert(
-                                release.toDomainModel(source.intId)
-                            )
-                        } catch (_: BundleImportError) {
-                            logger.warn("No rvp/mpp/jar found for ${source.url}, version ${release.tagName}")
-                            return@forEach
-                        }
-                    }
-                }
+                processSource(source)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                // Transient transport, server, and configuration failures preserve the source state.
+                logger.warn("Something went wrong while processing source ${source.url}", error)
             }
-            catch (e: Exception) {
-                logger.warn("Something went wrong while processing, error: ${e.cause}, ${e.message}, ${e.stackTrace}")
-            }
-
             logger.info("Source process completed")
         }
 
@@ -63,4 +56,84 @@ class RefreshBundlesJobService(
         logger.info("Process completed")
     }
 
+    private suspend fun processSource(source: SourceEntity) {
+        val resolved = hostResolver.resolve(source.url)
+        val credentialFingerprint = credentials.fingerprintFor(resolved.authority)
+        val now = OffsetDateTime.now(ZoneOffset.UTC)
+        val limitedUntil = rateLimitRepository.activeUntil(
+            resolved.authority,
+            credentialFingerprint,
+            now
+        )
+        if (limitedUntil != null) {
+            logger.info(
+                "Skipping source {} because git host {} is rate limited until {}",
+                source.url,
+                resolved.authority,
+                limitedUntil
+            )
+            return
+        }
+
+        try {
+            val metadata = resolved.client.getRepo(resolved.ref).toDomainModel(source.intId)
+            val bundles = resolved.client.getReleases(resolved.ref)
+                .mapNotNull { release ->
+                    try {
+                        release.toDomainModel(source.intId)
+                    } catch (_: BundleImportError) {
+                        logger.warn("No rvp/mpp/jar found for ${source.url}, version ${release.tagName}")
+                        null
+                    }
+                }
+
+            suspendTransaction {
+                // Update metatable
+                sourceMetadataRepository.upsert(metadata)
+
+                // Update bundle table
+                bundles.forEach(bundleRepository::upsert)
+
+                // Only a complete repository-and-releases refresh proves that the source recovered.
+                sourceRepository.setUnavailableReason(source.intId, null)
+                rateLimitRepository.clear(resolved.authority, credentialFingerprint)
+            }
+        } catch (error: ClientRequestException) {
+            handleClientFailure(
+                sourceId = source.intId,
+                sourceUrl = source.url,
+                authority = resolved.authority,
+                client = resolved.client,
+                credentialFingerprint = credentialFingerprint,
+                error = error
+            )
+        }
+    }
+
+    private fun handleClientFailure(
+        sourceId: Int,
+        sourceUrl: String,
+        authority: String,
+        client: GitHostClient,
+        credentialFingerprint: String,
+        error: ClientRequestException
+    ) {
+        val status = error.response.status
+        val unavailableReason = sourceUnavailableReason(status)
+        if (unavailableReason != null) {
+            sourceRepository.setUnavailableReason(sourceId, unavailableReason)
+            logger.warn("Source $sourceUrl is unavailable: $unavailableReason")
+            return
+        }
+
+        val now = OffsetDateTime.now(ZoneOffset.UTC)
+        val limitedUntil = client.rateLimitDeadline(status, error.response.headers, now)
+        if (limitedUntil != null) {
+            rateLimitRepository.record(authority, credentialFingerprint, limitedUntil)
+            logger.warn("Git host $authority is rate limited until $limitedUntil")
+            return
+        }
+
+        logger.warn("Git host request failed for source $sourceUrl with status $status")
+    }
 }

--- a/src/main/kotlin/me/brosssh/bundles/domain/services/jobs/RefreshBundlesJobService.kt
+++ b/src/main/kotlin/me/brosssh/bundles/domain/services/jobs/RefreshBundlesJobService.kt
@@ -1,6 +1,7 @@
 package me.brosssh.bundles.domain.services.jobs
 
 import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CancellationException
 import me.brosssh.bundles.db.entities.SourceEntity
 import me.brosssh.bundles.db.functions.refreshIsLatestFlag
@@ -110,7 +111,7 @@ class RefreshBundlesJobService(
         }
     }
 
-    private fun handleClientFailure(
+    private suspend fun handleClientFailure(
         sourceId: Int,
         sourceUrl: String,
         authority: String,
@@ -127,7 +128,12 @@ class RefreshBundlesJobService(
         }
 
         val now = OffsetDateTime.now(ZoneOffset.UTC)
-        val limitedUntil = client.rateLimitDeadline(status, error.response.headers, now)
+        val limitedUntil = client.rateLimitDeadline(
+            status,
+            error.response.headers,
+            now,
+            error.response.bodyAsText()
+        )
         if (limitedUntil != null) {
             rateLimitRepository.record(authority, credentialFingerprint, limitedUntil)
             logger.warn("Git host $authority is rate limited until $limitedUntil")

--- a/src/main/kotlin/me/brosssh/bundles/integrations/common/GitHostClient.kt
+++ b/src/main/kotlin/me/brosssh/bundles/integrations/common/GitHostClient.kt
@@ -1,6 +1,9 @@
 package me.brosssh.bundles.integrations.common
 
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
 import java.net.URI
+import java.time.OffsetDateTime
 
 /**
  * Identifies a repository on any supported git host.
@@ -91,6 +94,13 @@ data class ReleaseInfo(
 interface GitHostClient {
     suspend fun getRepo(ref: RepoRef): RepoInfo
     suspend fun getReleases(ref: RepoRef): List<ReleaseInfo>
+
+    /** Returns the provider-specific retry deadline when [status] and [headers] indicate throttling. */
+    fun rateLimitDeadline(
+        status: HttpStatusCode,
+        headers: Headers,
+        now: OffsetDateTime
+    ): OffsetDateTime?
 }
 
 /** Creates a provider client for a resolved scheme and authority. */

--- a/src/main/kotlin/me/brosssh/bundles/integrations/common/GitHostClient.kt
+++ b/src/main/kotlin/me/brosssh/bundles/integrations/common/GitHostClient.kt
@@ -101,6 +101,17 @@ interface GitHostClient {
         headers: Headers,
         now: OffsetDateTime
     ): OffsetDateTime?
+
+    /**
+     * Response-body-aware rate-limit hook for providers that describe throttling in an error body.
+     * Header-only clients retain the default behavior.
+     */
+    fun rateLimitDeadline(
+        status: HttpStatusCode,
+        headers: Headers,
+        now: OffsetDateTime,
+        responseBody: String?
+    ): OffsetDateTime? = rateLimitDeadline(status, headers, now)
 }
 
 /** Creates a provider client for a resolved scheme and authority. */

--- a/src/main/kotlin/me/brosssh/bundles/integrations/common/GitHostCredentials.kt
+++ b/src/main/kotlin/me/brosssh/bundles/integrations/common/GitHostCredentials.kt
@@ -1,6 +1,8 @@
 package me.brosssh.bundles.integrations.common
 
 import java.net.URI
+import java.security.MessageDigest
+import java.util.HexFormat
 
 /** Authority-keyed personal access tokens for git hosts. */
 class GitHostCredentials private constructor(
@@ -9,7 +11,17 @@ class GitHostCredentials private constructor(
     /** Returns the PAT configured for [authority]. */
     fun patFor(authority: String): String? = pats[authority.lowercase()]
 
+    /** Stable credential identity for persisted rate-limit state; never exposes the PAT itself. */
+    fun fingerprintFor(authority: String): String =
+        patFor(authority)?.let { pat ->
+            HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA-256").digest(pat.toByteArray(Charsets.UTF_8))
+            )
+        } ?: ANONYMOUS_FINGERPRINT
+
     companion object {
+        const val ANONYMOUS_FINGERPRINT = "anonymous"
+
         /**
          * Parses comma-separated `host[:port]=pat` entries. The first `=` separates the authority,
          * so tokens may contain `=`; commas are reserved as entry separators. Validation errors

--- a/src/main/kotlin/me/brosssh/bundles/integrations/common/GitHostHttpStatus.kt
+++ b/src/main/kotlin/me/brosssh/bundles/integrations/common/GitHostHttpStatus.kt
@@ -1,0 +1,50 @@
+package me.brosssh.bundles.integrations.common
+
+import io.ktor.http.HttpStatusCode
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+internal const val DEFAULT_RATE_LIMIT_RETRY_DELAY_SECONDS = 60L
+
+internal val UnavailableForLegalReasonsStatus =
+    HttpStatusCode(451, "Unavailable For Legal Reasons")
+
+private val sourceUnavailableStatuses = mapOf(
+    HttpStatusCode.NotFound.value to "Not Found",
+    HttpStatusCode.Gone.value to "Gone",
+    UnavailableForLegalReasonsStatus.value to "Unavailable For Legal Reasons"
+)
+
+internal fun sourceUnavailableReason(status: HttpStatusCode): String? =
+    sourceUnavailableStatuses[status.value]?.let { reason -> "${status.value}: $reason" }
+
+internal fun resolvedRateLimitDeadline(
+    retryAfter: String?,
+    reset: OffsetDateTime?,
+    now: OffsetDateTime
+): OffsetDateTime =
+    (parseRetryAfter(retryAfter, now) ?: reset)
+        ?.takeIf { it.isAfter(now) }
+        ?: now.plusSeconds(DEFAULT_RATE_LIMIT_RETRY_DELAY_SECONDS)
+
+internal fun parseEpochSeconds(value: String?): OffsetDateTime? =
+    value?.trim()?.toLongOrNull()
+        ?.let { runCatching { Instant.ofEpochSecond(it).atOffset(ZoneOffset.UTC) }.getOrNull() }
+
+internal fun parseHttpDate(value: String?): OffsetDateTime? =
+    value?.let {
+        runCatching {
+            ZonedDateTime.parse(it.trim(), DateTimeFormatter.RFC_1123_DATE_TIME).toOffsetDateTime()
+        }.getOrNull()
+    }
+
+private fun parseRetryAfter(value: String?, now: OffsetDateTime): OffsetDateTime? {
+    if (value.isNullOrBlank()) return null
+    return value.trim().toLongOrNull()
+        ?.takeIf { it >= 0 }
+        ?.let(now::plusSeconds)
+        ?: parseHttpDate(value)
+}

--- a/src/main/kotlin/me/brosssh/bundles/integrations/gitea/GiteaHostClient.kt
+++ b/src/main/kotlin/me/brosssh/bundles/integrations/gitea/GiteaHostClient.kt
@@ -2,8 +2,11 @@ package me.brosssh.bundles.integrations.gitea
 
 import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.plugins.expectSuccess
 import io.ktor.client.request.*
+import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import me.brosssh.bundles.integrations.common.GitHostClient
 import me.brosssh.bundles.integrations.common.GitHostCredentials
 import me.brosssh.bundles.integrations.common.GitHostClientFactory
@@ -13,6 +16,8 @@ import me.brosssh.bundles.integrations.common.ReleaseInfo
 import me.brosssh.bundles.integrations.common.AssetInfo
 import me.brosssh.bundles.integrations.common.nextPageUrl
 import me.brosssh.bundles.integrations.common.resolveAvatar
+import me.brosssh.bundles.integrations.common.resolvedRateLimitDeadline
+import java.time.OffsetDateTime
 
 /**
  * Client for Gitea-compatible instances, including Forgejo and the Forgejo-based Codeberg service.
@@ -37,9 +42,24 @@ class GiteaHostClient(
         pat?.let { header(HttpHeaders.Authorization, "token $it") }
     }
 
+    override fun rateLimitDeadline(
+        status: HttpStatusCode,
+        headers: Headers,
+        now: OffsetDateTime
+    ): OffsetDateTime? {
+        if (status != HttpStatusCode.TooManyRequests) return null
+
+        return resolvedRateLimitDeadline(
+            retryAfter = headers[HttpHeaders.RetryAfter],
+            reset = null,
+            now = now
+        )
+    }
+
     override suspend fun getRepo(ref: RepoRef): RepoInfo =
         client
             .get("$baseUrl/api/v1/repos/${ref.namespace}/${ref.repo}") {
+                expectSuccess = true
                 authenticate()
             }
             .body<GiteaRepoDto>()
@@ -52,6 +72,7 @@ class GiteaHostClient(
 
         while (nextUrl != null) {
             val response = client.get(nextUrl) {
+                expectSuccess = true
                 authenticate()
             }
             releases += response.body<List<GiteaReleaseDto>>()

--- a/src/main/kotlin/me/brosssh/bundles/integrations/github/GithubClient.kt
+++ b/src/main/kotlin/me/brosssh/bundles/integrations/github/GithubClient.kt
@@ -35,12 +35,21 @@ class GithubClient(
         status: HttpStatusCode,
         headers: Headers,
         now: OffsetDateTime
+    ): OffsetDateTime? = rateLimitDeadline(status, headers, now, null)
+
+    override fun rateLimitDeadline(
+        status: HttpStatusCode,
+        headers: Headers,
+        now: OffsetDateTime,
+        responseBody: String?
     ): OffsetDateTime? {
         val retryAfter = headers[HttpHeaders.RetryAfter]
         val rateLimited =
             status == HttpStatusCode.TooManyRequests ||
                 (status == HttpStatusCode.Forbidden &&
-                    (headers["X-RateLimit-Remaining"]?.trim() == "0" || retryAfter != null))
+                    (headers["X-RateLimit-Remaining"]?.trim() == "0" ||
+                        retryAfter != null ||
+                        responseBody.indicatesSecondaryRateLimit()))
         if (!rateLimited) return null
 
         return resolvedRateLimitDeadline(
@@ -80,6 +89,12 @@ class GithubClient(
             .toRepoInfo()
 
 }
+
+private fun String?.indicatesSecondaryRateLimit(): Boolean =
+    this?.let { body ->
+        body.contains("secondary rate limit", ignoreCase = true) ||
+            body.contains("abuse detection", ignoreCase = true)
+    } == true
 
 fun GithubRepoDto.toRepoInfo() = RepoInfo(
     ownerName = owner.name,

--- a/src/main/kotlin/me/brosssh/bundles/integrations/github/GithubClient.kt
+++ b/src/main/kotlin/me/brosssh/bundles/integrations/github/GithubClient.kt
@@ -2,9 +2,13 @@ package me.brosssh.bundles.integrations.github
 
 import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.plugins.expectSuccess
 import io.ktor.client.request.*
+import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import me.brosssh.bundles.integrations.common.*
+import java.time.OffsetDateTime
 
 class GithubClientFactory(
     private val client: HttpClient,
@@ -27,6 +31,25 @@ class GithubClient(
         pat?.let { header(HttpHeaders.Authorization, "Bearer $it") }
     }
 
+    override fun rateLimitDeadline(
+        status: HttpStatusCode,
+        headers: Headers,
+        now: OffsetDateTime
+    ): OffsetDateTime? {
+        val retryAfter = headers[HttpHeaders.RetryAfter]
+        val rateLimited =
+            status == HttpStatusCode.TooManyRequests ||
+                (status == HttpStatusCode.Forbidden &&
+                    (headers["X-RateLimit-Remaining"]?.trim() == "0" || retryAfter != null))
+        if (!rateLimited) return null
+
+        return resolvedRateLimitDeadline(
+            retryAfter = retryAfter,
+            reset = parseEpochSeconds(headers["X-RateLimit-Reset"]),
+            now = now
+        )
+    }
+
     override suspend fun getReleases(ref: RepoRef): List<ReleaseInfo> {
         val releases = mutableListOf<ReleaseInfo>()
 
@@ -34,6 +57,7 @@ class GithubClient(
 
         while (nextUrl != null) {
             val response = client.get(nextUrl) {
+                expectSuccess = true
                 authenticate()
                 header(HttpHeaders.Accept, "application/vnd.github+json")
             }
@@ -49,6 +73,7 @@ class GithubClient(
     override suspend fun getRepo(ref: RepoRef): RepoInfo =
         client
             .get("$baseUrl/repos/${ref.namespace}/${ref.repo}") {
+                expectSuccess = true
                 authenticate()
             }
             .body<GithubRepoDto>()

--- a/src/main/kotlin/me/brosssh/bundles/integrations/gitlab/GitlabHostClient.kt
+++ b/src/main/kotlin/me/brosssh/bundles/integrations/gitlab/GitlabHostClient.kt
@@ -2,7 +2,11 @@ package me.brosssh.bundles.integrations.gitlab
 
 import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.plugins.expectSuccess
 import io.ktor.client.request.*
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import me.brosssh.bundles.integrations.common.AssetInfo
 import me.brosssh.bundles.integrations.common.GitHostClient
 import me.brosssh.bundles.integrations.common.GitHostCredentials
@@ -10,6 +14,9 @@ import me.brosssh.bundles.integrations.common.GitHostClientFactory
 import me.brosssh.bundles.integrations.common.RepoInfo
 import me.brosssh.bundles.integrations.common.RepoRef
 import me.brosssh.bundles.integrations.common.ReleaseInfo
+import me.brosssh.bundles.integrations.common.parseEpochSeconds
+import me.brosssh.bundles.integrations.common.parseHttpDate
+import me.brosssh.bundles.integrations.common.resolvedRateLimitDeadline
 import me.brosssh.bundles.integrations.common.resolveAvatar
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
@@ -57,11 +64,31 @@ class GitlabHostClient(
         pat?.let { header("PRIVATE-TOKEN", it) }
     }
 
+    override fun rateLimitDeadline(
+        status: HttpStatusCode,
+        headers: Headers,
+        now: OffsetDateTime
+    ): OffsetDateTime? {
+        val rateLimited =
+            status == HttpStatusCode.TooManyRequests ||
+                (status == HttpStatusCode.Forbidden &&
+                    headers["RateLimit-Remaining"]?.trim() == "0")
+        if (!rateLimited) return null
+
+        return resolvedRateLimitDeadline(
+            retryAfter = headers[HttpHeaders.RetryAfter],
+            reset = parseEpochSeconds(headers["RateLimit-Reset"])
+                ?: parseHttpDate(headers["RateLimit-ResetTime"]),
+            now = now
+        )
+    }
+
     private fun projectId(ref: RepoRef) = "${ref.namespace}/${ref.repo}".replace("/", "%2F")
 
     override suspend fun getRepo(ref: RepoRef): RepoInfo {
         val project = client
             .get("$baseUrl/api/v4/projects/${projectId(ref)}") {
+                expectSuccess = true
                 authenticate()
             }
             .body<GitlabProjectDto>()
@@ -91,6 +118,7 @@ class GitlabHostClient(
             val page = nextPage
             val response = client
                 .get("$baseUrl/api/v4/projects/${projectId(ref)}/releases?per_page=100&page=$page") {
+                    expectSuccess = true
                     authenticate()
                 }
             releases += response.body<List<GitlabReleaseDto>>().map { it.toReleaseInfo() }

--- a/src/main/kotlin/me/brosssh/bundles/plugins/ConfigureDatabase.kt
+++ b/src/main/kotlin/me/brosssh/bundles/plugins/ConfigureDatabase.kt
@@ -22,7 +22,8 @@ fun Application.configureDatabase() {
             RefreshJobTable,
             SourceTable,
             SourceMetadataTable,
-            PatchPackageTable
+            PatchPackageTable,
+            GitHostRateLimitTable
         )
     }
 }

--- a/src/main/kotlin/me/brosssh/bundles/repositories/BundleRepository.kt
+++ b/src/main/kotlin/me/brosssh/bundles/repositories/BundleRepository.kt
@@ -9,6 +9,7 @@ import me.brosssh.bundles.domain.models.BundleType
 import me.brosssh.bundles.domain.models.ReleaseChannel
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
@@ -82,7 +83,9 @@ class BundleRepository {
         (BundleTable innerJoin SourceTable)
             .selectAll()
             .where {
-                (BundleTable.needPatchesUpdate eq true) and enabledSourceFilter
+                (BundleTable.needPatchesUpdate eq true) and
+                    enabledSourceFilter and
+                    availableSourceFilter
             }
             .map { row ->
                 BundlePatchCandidate(
@@ -126,7 +129,10 @@ class BundleRepository {
             (BundleTable.bundleType eq bundleType.value) and
                 (BundleTable.needPatchesUpdate eq false) and
                 BundleTable.patcherFailureFingerprint.isNotNull() and
-                (BundleTable.patcherFailureFingerprint neq runtimeFingerprint)
+                (BundleTable.patcherFailureFingerprint neq runtimeFingerprint) and
+                (BundleTable.sourceFk inSubQuery SourceTable
+                    .select(SourceTable.id)
+                    .where { availableSourceFilter })
         }) {
             it[BundleTable.needPatchesUpdate] = true
         }
@@ -212,6 +218,10 @@ class BundleRepository {
     // v1 and v2 expose only bundles from enabled sources; explicit v3 lookups do not use this filter.
     private val enabledSourceFilter: Op<Boolean>
         get() = SourceTable.enabled eq true
+
+    // Temporarily unavailable sources remain served but do not enter the patch extraction queue.
+    private val availableSourceFilter: Op<Boolean>
+        get() = SourceTable.unavailableReason.isNull()
 
     private fun sourceUrlFilter(sourceUrl: String) =
         (SourceTable.url eq sourceUrl) or (SourceTable.url eq "$sourceUrl/")

--- a/src/main/kotlin/me/brosssh/bundles/repositories/GitHostRateLimitRepository.kt
+++ b/src/main/kotlin/me/brosssh/bundles/repositories/GitHostRateLimitRepository.kt
@@ -1,0 +1,60 @@
+package me.brosssh.bundles.repositories
+
+import me.brosssh.bundles.db.tables.GitHostRateLimitTable
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import java.time.OffsetDateTime
+
+class GitHostRateLimitRepository {
+    fun activeUntil(
+        authority: String,
+        credentialFingerprint: String,
+        now: OffsetDateTime
+    ): OffsetDateTime? = transaction {
+        GitHostRateLimitTable
+            .selectAll()
+            .where { keyMatches(authority, credentialFingerprint) }
+            .limit(1)
+            .singleOrNull()
+            ?.get(GitHostRateLimitTable.rateLimitedUntil)
+            ?.takeIf { it.isAfter(now) }
+    }
+
+    fun record(
+        authority: String,
+        credentialFingerprint: String,
+        rateLimitedUntil: OffsetDateTime
+    ) = transaction {
+        val existing = GitHostRateLimitTable
+            .selectAll()
+            .where { keyMatches(authority, credentialFingerprint) }
+            .forUpdate()
+            .limit(1)
+            .singleOrNull()
+
+        if (existing == null) {
+            GitHostRateLimitTable.insert {
+                it[GitHostRateLimitTable.authority] = authority.lowercase()
+                it[GitHostRateLimitTable.credentialFingerprint] = credentialFingerprint
+                it[GitHostRateLimitTable.rateLimitedUntil] = rateLimitedUntil
+            }
+        } else if (rateLimitedUntil.isAfter(existing[GitHostRateLimitTable.rateLimitedUntil])) {
+            GitHostRateLimitTable.update({ keyMatches(authority, credentialFingerprint) }) {
+                it[GitHostRateLimitTable.rateLimitedUntil] = rateLimitedUntil
+            }
+        }
+    }
+
+    fun clear(authority: String, credentialFingerprint: String) = transaction {
+        GitHostRateLimitTable.deleteWhere { keyMatches(authority, credentialFingerprint) }
+    }
+
+    private fun keyMatches(authority: String, credentialFingerprint: String) =
+        (GitHostRateLimitTable.authority eq authority.lowercase()) and
+            (GitHostRateLimitTable.credentialFingerprint eq credentialFingerprint)
+}

--- a/src/main/kotlin/me/brosssh/bundles/repositories/SourceRepository.kt
+++ b/src/main/kotlin/me/brosssh/bundles/repositories/SourceRepository.kt
@@ -12,10 +12,17 @@ import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 
 class SourceRepository {
     fun getEnabled(): List<SourceEntity> = transaction {
         SourceEntity.find { SourceTable.enabled eq true }.toList()
+    }
+
+    fun setUnavailableReason(sourceId: Int, reason: String?) = transaction {
+        SourceTable.update({ SourceTable.id eq sourceId }) {
+            it[unavailableReason] = reason
+        }
     }
 
     fun hardDelete(sourceUrl: String): SourceDeletionResult = transaction {

--- a/src/main/resources/hasura/metadata.json
+++ b/src/main/resources/hasura/metadata.json
@@ -42,7 +42,6 @@
                     "is_latest",
                     "is_prerelease",
                     "need_patches_update",
-                    "patcher_failure",
                     "bundle_type",
                     "created_at",
                     "download_url",

--- a/src/main/resources/hasura/metadata.json
+++ b/src/main/resources/hasura/metadata.json
@@ -42,6 +42,7 @@
                     "is_latest",
                     "is_prerelease",
                     "need_patches_update",
+                    "patcher_failure",
                     "bundle_type",
                     "created_at",
                     "download_url",
@@ -260,7 +261,8 @@
                   "columns": [
                     "url",
                     "id",
-                    "enabled"
+                    "enabled",
+                    "unavailable_reason"
                   ],
                   "filter": {},
                   "allow_aggregations": true

--- a/src/test/kotlin/me/brosssh/bundles/db/HasuraMetadataTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/db/HasuraMetadataTest.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class HasuraMetadataTest {
@@ -43,6 +44,14 @@ class HasuraMetadataTest {
 
         assertTrue("enabled" in columns)
         assertEquals(JsonObject(emptyMap()), permission["filter"])
+    }
+
+    @Test
+    fun `public bundle data does not expose raw patcher failures`() {
+        val columns = userPermission("bundle")["columns"]!!.jsonArray
+            .map { it.jsonPrimitive.content }
+
+        assertFalse("patcher_failure" in columns)
     }
 
     private fun enabledSourceFilter() = buildJsonObject {

--- a/src/test/kotlin/me/brosssh/bundles/domain/services/jobs/RefreshBundlesJobServiceTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/domain/services/jobs/RefreshBundlesJobServiceTest.kt
@@ -1,0 +1,231 @@
+package me.brosssh.bundles.domain.services.jobs
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.expectSuccess
+import io.ktor.client.request.get
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import me.brosssh.bundles.db.tables.BundleTable
+import me.brosssh.bundles.db.tables.GitHostRateLimitTable
+import me.brosssh.bundles.db.tables.RefreshJobTable
+import me.brosssh.bundles.db.tables.SourceMetadataTable
+import me.brosssh.bundles.db.tables.SourceTable
+import me.brosssh.bundles.integrations.GitHostType
+import me.brosssh.bundles.integrations.HostResolver
+import me.brosssh.bundles.integrations.common.GitHostClient
+import me.brosssh.bundles.integrations.common.GitHostClientFactory
+import me.brosssh.bundles.integrations.common.GitHostCredentials
+import me.brosssh.bundles.integrations.common.ReleaseInfo
+import me.brosssh.bundles.integrations.common.RepoInfo
+import me.brosssh.bundles.integrations.common.RepoRef
+import me.brosssh.bundles.integrations.common.UnavailableForLegalReasonsStatus
+import me.brosssh.bundles.integrations.github.GithubClient
+import me.brosssh.bundles.repositories.BundleRepository
+import me.brosssh.bundles.repositories.GitHostRateLimitRepository
+import me.brosssh.bundles.repositories.RefreshJobRepository
+import me.brosssh.bundles.repositories.SourceMetadataRepository
+import me.brosssh.bundles.repositories.SourceRepository
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class RefreshBundlesJobServiceTest {
+    private lateinit var database: Database
+    private lateinit var rateLimitRepository: GitHostRateLimitRepository
+
+    @BeforeTest
+    fun setUp() {
+        database = Database.connect(
+            url = "jdbc:h2:mem:${UUID.randomUUID()};MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+            driver = "org.h2.Driver"
+        )
+        TransactionManager.defaultDatabase = database
+        transaction(database) {
+            SchemaUtils.create(
+                SourceTable,
+                SourceMetadataTable,
+                BundleTable,
+                RefreshJobTable,
+                GitHostRateLimitTable
+            )
+        }
+        rateLimitRepository = GitHostRateLimitRepository()
+    }
+
+    @Test
+    fun `unavailable source is rechecked and cleared after a complete refresh`() = runBlocking {
+        insertSource("https://github.com/example/patches")
+        val client = MutableGitHostClient(UnavailableForLegalReasonsStatus)
+        val service = service(client)
+
+        service.refresh().job.join()
+
+        assertEquals(
+            "451: Unavailable For Legal Reasons",
+            unavailableReason("https://github.com/example/patches")
+        )
+        assertEquals(1, client.repoRequests)
+        assertEquals(0, client.releaseRequests)
+
+        client.failureStatus = null
+        service.refresh().job.join()
+
+        assertNull(unavailableReason("https://github.com/example/patches"))
+        assertEquals(2, client.repoRequests)
+        assertEquals(1, client.releaseRequests)
+    }
+
+    @Test
+    fun `source remains unavailable until repository and releases both succeed`() = runBlocking {
+        val sourceUrl = "https://github.com/example/patches"
+        insertSource(sourceUrl, "404: Not Found")
+        val client = MutableGitHostClient(
+            failureStatus = HttpStatusCode.InternalServerError,
+            failReleases = true
+        )
+        val service = service(client)
+
+        service.refresh().job.join()
+
+        assertEquals("404: Not Found", unavailableReason(sourceUrl))
+        assertEquals(0, sourceMetadataCount())
+
+        client.failureStatus = null
+        service.refresh().job.join()
+
+        assertNull(unavailableReason(sourceUrl))
+        assertEquals(1, sourceMetadataCount())
+    }
+
+    @Test
+    fun `rate limit suppresses later sources sharing the host and credential`() = runBlocking {
+        insertSource("https://github.com/example/one")
+        insertSource("https://github.com/example/two")
+        val client = MutableGitHostClient(
+            failureStatus = HttpStatusCode.TooManyRequests,
+            failureHeaders = headersOf("Retry-After", "120")
+        )
+        val credentials = GitHostCredentials.fromEnv("github.com=secret-token")
+        val service = service(client, credentials)
+
+        service.refresh().job.join()
+
+        assertEquals(1, client.repoRequests)
+        assertNull(unavailableReason("https://github.com/example/one"))
+        assertNull(unavailableReason("https://github.com/example/two"))
+        assertNotNull(
+            rateLimitRepository.activeUntil(
+                "github.com",
+                credentials.fingerprintFor("github.com"),
+                OffsetDateTime.now(ZoneOffset.UTC)
+            )
+        )
+
+        client.failureStatus = null
+        service.refresh().job.join()
+
+        assertEquals(1, client.repoRequests)
+    }
+
+    private fun service(
+        client: GitHostClient,
+        credentials: GitHostCredentials = GitHostCredentials.fromEnv("")
+    ) = RefreshBundlesJobService(
+        RefreshJobRepository(),
+        HostResolver(
+            factories = mapOf(
+                GitHostType.GITHUB to GitHostClientFactory { _, _ -> client }
+            )
+        ),
+        SourceRepository(),
+        SourceMetadataRepository(),
+        BundleRepository(),
+        credentials,
+        rateLimitRepository
+    )
+
+    private fun insertSource(url: String, unavailableReason: String? = null) = transaction(database) {
+        SourceTable.insert {
+            it[SourceTable.url] = url
+            it[SourceTable.enabled] = true
+            it[SourceTable.unavailableReason] = unavailableReason
+        }
+    }
+
+    private fun sourceMetadataCount(): Long = transaction(database) {
+        SourceMetadataTable.selectAll().count()
+    }
+
+    private fun unavailableReason(url: String): String? = transaction(database) {
+        SourceTable
+            .selectAll()
+            .where { SourceTable.url eq url }
+            .single()[SourceTable.unavailableReason]
+    }
+
+    private class MutableGitHostClient(
+        var failureStatus: HttpStatusCode?,
+        private val failureHeaders: Headers = Headers.Empty,
+        private val failReleases: Boolean = false
+    ) : GitHostClient {
+        var repoRequests = 0
+        var releaseRequests = 0
+
+        private val errorClient = HttpClient(MockEngine {
+            respond(
+                content = "{}",
+                status = requireNotNull(failureStatus),
+                headers = failureHeaders
+            )
+        })
+
+        override fun rateLimitDeadline(
+            status: HttpStatusCode,
+            headers: Headers,
+            now: OffsetDateTime
+        ): OffsetDateTime? = GithubClient(errorClient).rateLimitDeadline(status, headers, now)
+
+        override suspend fun getRepo(ref: RepoRef): RepoInfo {
+            repoRequests++
+            if (failureStatus != null && !failReleases) failRequest(ref)
+            return RepoInfo(
+                ownerName = ref.namespace,
+                ownerAvatarUrl = "https://example.com/avatar.png",
+                repoName = ref.repo,
+                repoDescription = null,
+                repoStars = 1,
+                isRepoArchived = false,
+                repoPushedAt = "2026-08-31T12:00:00Z"
+            )
+        }
+
+        override suspend fun getReleases(ref: RepoRef): List<ReleaseInfo> {
+            releaseRequests++
+            if (failureStatus != null && failReleases) failRequest(ref)
+            return emptyList()
+        }
+
+        private suspend fun failRequest(ref: RepoRef): Nothing {
+            errorClient.get("https://api.github.test/repos/${ref.namespace}/${ref.repo}") {
+                expectSuccess = true
+            }
+            error("Expected a failed git-host response")
+        }
+    }
+}

--- a/src/test/kotlin/me/brosssh/bundles/domain/services/jobs/RefreshBundlesJobServiceTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/domain/services/jobs/RefreshBundlesJobServiceTest.kt
@@ -143,6 +143,28 @@ class RefreshBundlesJobServiceTest {
         assertEquals(1, client.repoRequests)
     }
 
+    @Test
+    fun `GitHub secondary rate-limit body suppresses later sources`() = runBlocking {
+        insertSource("https://github.com/example/one")
+        insertSource("https://github.com/example/two")
+        val client = MutableGitHostClient(
+            failureStatus = HttpStatusCode.Forbidden,
+            failureBody = """{"message":"You have exceeded a secondary rate limit."}"""
+        )
+        val service = service(client)
+
+        service.refresh().job.join()
+
+        assertEquals(1, client.repoRequests)
+        assertNotNull(
+            rateLimitRepository.activeUntil(
+                "github.com",
+                GitHostCredentials.ANONYMOUS_FINGERPRINT,
+                OffsetDateTime.now(ZoneOffset.UTC)
+            )
+        )
+    }
+
     private fun service(
         client: GitHostClient,
         credentials: GitHostCredentials = GitHostCredentials.fromEnv("")
@@ -182,6 +204,7 @@ class RefreshBundlesJobServiceTest {
     private class MutableGitHostClient(
         var failureStatus: HttpStatusCode?,
         private val failureHeaders: Headers = Headers.Empty,
+        private val failureBody: String = "{}",
         private val failReleases: Boolean = false
     ) : GitHostClient {
         var repoRequests = 0
@@ -189,7 +212,7 @@ class RefreshBundlesJobServiceTest {
 
         private val errorClient = HttpClient(MockEngine {
             respond(
-                content = "{}",
+                content = failureBody,
                 status = requireNotNull(failureStatus),
                 headers = failureHeaders
             )
@@ -200,6 +223,14 @@ class RefreshBundlesJobServiceTest {
             headers: Headers,
             now: OffsetDateTime
         ): OffsetDateTime? = GithubClient(errorClient).rateLimitDeadline(status, headers, now)
+
+        override fun rateLimitDeadline(
+            status: HttpStatusCode,
+            headers: Headers,
+            now: OffsetDateTime,
+            responseBody: String?
+        ): OffsetDateTime? =
+            GithubClient(errorClient).rateLimitDeadline(status, headers, now, responseBody)
 
         override suspend fun getRepo(ref: RepoRef): RepoInfo {
             repoRequests++

--- a/src/test/kotlin/me/brosssh/bundles/integrations/GitHostClientHttpFailureTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/integrations/GitHostClientHttpFailureTest.kt
@@ -1,0 +1,56 @@
+package me.brosssh.bundles.integrations
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import me.brosssh.bundles.integrations.common.RepoRef
+import me.brosssh.bundles.integrations.gitea.GiteaHostClient
+import me.brosssh.bundles.integrations.github.GithubClient
+import me.brosssh.bundles.integrations.gitlab.GitlabHostClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class GitHostClientHttpFailureTest {
+    @Test
+    fun `GitHub exposes unsuccessful repository status`() = runBlocking {
+        assertStatus(HttpStatusCode.NotFound) { client ->
+            GithubClient(client, "https://api.github.test").getRepo(REPO)
+        }
+    }
+
+    @Test
+    fun `GitLab exposes unsuccessful repository status`() = runBlocking {
+        assertStatus(HttpStatusCode.Gone) { client ->
+            GitlabHostClient(client, "https://gitlab.test").getRepo(REPO)
+        }
+    }
+
+    @Test
+    fun `Gitea exposes unsuccessful repository status`() = runBlocking {
+        assertStatus(HttpStatusCode(451, "Unavailable For Legal Reasons")) { client ->
+            GiteaHostClient(client, "https://gitea.test").getRepo(REPO)
+        }
+    }
+
+    private suspend fun assertStatus(
+        status: HttpStatusCode,
+        request: suspend (HttpClient) -> Unit
+    ) {
+        val client = HttpClient(MockEngine { respond("{}", status) })
+
+        val error = assertFailsWith<ClientRequestException> {
+            request(client)
+        }
+
+        assertEquals(status.value, error.response.status.value)
+        client.close()
+    }
+
+    private companion object {
+        val REPO = RepoRef("example", "patches")
+    }
+}

--- a/src/test/kotlin/me/brosssh/bundles/integrations/common/GitHostCredentialsTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/integrations/common/GitHostCredentialsTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 
 class GitHostCredentialsTest {
@@ -44,6 +45,20 @@ class GitHostCredentialsTest {
         )
 
         assertEquals("current-token", credentials.patFor("github.com"))
+    }
+
+    @Test
+    fun `credential fingerprints are stable without storing the PAT`() {
+        val credentials = GitHostCredentials.fromEnv("github.com=super-secret-token")
+        val fingerprint = credentials.fingerprintFor("GITHUB.COM")
+
+        assertEquals(64, fingerprint.length)
+        assertEquals(fingerprint, credentials.fingerprintFor("github.com"))
+        assertNotEquals("super-secret-token", fingerprint)
+        assertEquals(
+            GitHostCredentials.ANONYMOUS_FINGERPRINT,
+            credentials.fingerprintFor("gitlab.com")
+        )
     }
 
     @Test

--- a/src/test/kotlin/me/brosssh/bundles/integrations/common/GitHostHttpStatusTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/integrations/common/GitHostHttpStatusTest.kt
@@ -88,6 +88,19 @@ class GitHostHttpStatusTest {
     }
 
     @Test
+    fun `GitHub secondary-limit 403 without headers uses the fallback`() {
+        assertEquals(
+            now.plusSeconds(DEFAULT_RATE_LIMIT_RETRY_DELAY_SECONDS),
+            github.rateLimitDeadline(
+                HttpStatusCode.Forbidden,
+                Headers.Empty,
+                now,
+                """{"message":"You have exceeded a secondary rate limit."}"""
+            )
+        )
+    }
+
+    @Test
     fun `GitLab remaining header can prove a rate-limit 403`() {
         assertEquals(
             now.plusSeconds(DEFAULT_RATE_LIMIT_RETRY_DELAY_SECONDS),
@@ -104,6 +117,14 @@ class GitHostHttpStatusTest {
         listOf(github, gitlab, gitea).forEach { client ->
             assertNull(client.rateLimitDeadline(HttpStatusCode.Forbidden, Headers.Empty, now))
         }
+        assertNull(
+            github.rateLimitDeadline(
+                HttpStatusCode.Forbidden,
+                Headers.Empty,
+                now,
+                """{"message":"Resource not accessible by integration"}"""
+            )
+        )
     }
 
     @Test

--- a/src/test/kotlin/me/brosssh/bundles/integrations/common/GitHostHttpStatusTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/integrations/common/GitHostHttpStatusTest.kt
@@ -1,0 +1,128 @@
+package me.brosssh.bundles.integrations.common
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import me.brosssh.bundles.integrations.gitea.GiteaHostClient
+import me.brosssh.bundles.integrations.github.GithubClient
+import me.brosssh.bundles.integrations.gitlab.GitlabHostClient
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GitHostHttpStatusTest {
+    private val now = OffsetDateTime.of(2026, 8, 31, 12, 0, 0, 0, ZoneOffset.UTC)
+    private val httpClient = HttpClient(MockEngine { respond("{}") })
+    private val github = GithubClient(httpClient)
+    private val gitlab = GitlabHostClient(httpClient, "https://gitlab.test")
+    private val gitea = GiteaHostClient(httpClient, "https://gitea.test")
+
+    @Test
+    fun `only source-level unavailable statuses produce a reason`() {
+        assertEquals("404: Not Found", sourceUnavailableReason(HttpStatusCode.NotFound))
+        assertEquals("410: Gone", sourceUnavailableReason(HttpStatusCode.Gone))
+        assertEquals(
+            "451: Unavailable For Legal Reasons",
+            sourceUnavailableReason(UnavailableForLegalReasonsStatus)
+        )
+        assertNull(sourceUnavailableReason(HttpStatusCode.Forbidden))
+        assertNull(sourceUnavailableReason(HttpStatusCode.TooManyRequests))
+    }
+
+    @Test
+    fun `429 honors Retry-After`() {
+        assertEquals(
+            now.plusSeconds(90),
+            github.rateLimitDeadline(
+                HttpStatusCode.TooManyRequests,
+                headersOf("Retry-After", "90"),
+                now
+            )
+        )
+    }
+
+    @Test
+    fun `GitLab RateLimit-Reset is interpreted as an epoch timestamp`() {
+        val reset = now.plusMinutes(10)
+        assertEquals(
+            reset,
+            gitlab.rateLimitDeadline(
+                HttpStatusCode.TooManyRequests,
+                headersOf("RateLimit-Reset", reset.toEpochSecond().toString()),
+                now
+            )
+        )
+    }
+
+    @Test
+    fun `GitHub rate-limit 403 honors its reset epoch`() {
+        val reset = now.plusMinutes(15)
+        assertEquals(
+            reset,
+            github.rateLimitDeadline(
+                HttpStatusCode.Forbidden,
+                headersOf(
+                    "X-RateLimit-Remaining" to listOf("0"),
+                    "X-RateLimit-Reset" to listOf(reset.toEpochSecond().toString())
+                ),
+                now
+            )
+        )
+    }
+
+    @Test
+    fun `GitHub secondary-limit 403 honors Retry-After`() {
+        assertEquals(
+            now.plusSeconds(30),
+            github.rateLimitDeadline(
+                HttpStatusCode.Forbidden,
+                headersOf("Retry-After", "30"),
+                now
+            )
+        )
+    }
+
+    @Test
+    fun `GitLab remaining header can prove a rate-limit 403`() {
+        assertEquals(
+            now.plusSeconds(DEFAULT_RATE_LIMIT_RETRY_DELAY_SECONDS),
+            gitlab.rateLimitDeadline(
+                HttpStatusCode.Forbidden,
+                headersOf("RateLimit-Remaining", "0"),
+                now
+            )
+        )
+    }
+
+    @Test
+    fun `ordinary 403 is not treated as rate limiting`() {
+        listOf(github, gitlab, gitea).forEach { client ->
+            assertNull(client.rateLimitDeadline(HttpStatusCode.Forbidden, Headers.Empty, now))
+        }
+    }
+
+    @Test
+    fun `missing or expired reset headers use a short fallback`() {
+        assertEquals(
+            now.plusSeconds(DEFAULT_RATE_LIMIT_RETRY_DELAY_SECONDS),
+            gitea.rateLimitDeadline(
+                HttpStatusCode.TooManyRequests,
+                Headers.Empty,
+                now
+            )
+        )
+        assertEquals(
+            now.plusSeconds(DEFAULT_RATE_LIMIT_RETRY_DELAY_SECONDS),
+            github.rateLimitDeadline(
+                HttpStatusCode.TooManyRequests,
+                headersOf("X-RateLimit-Reset", now.minusMinutes(1).toEpochSecond().toString()),
+                now
+            )
+        )
+    }
+}

--- a/src/test/kotlin/me/brosssh/bundles/repositories/DisabledSourceRepositoryTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/repositories/DisabledSourceRepositoryTest.kt
@@ -22,6 +22,7 @@ import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -75,6 +76,50 @@ class DisabledSourceRepositoryTest {
         assertNotNull(repository.findByRepoAndVersion(OWNER, REPO, VERSION))
         assertNotNull(repository.findByRepoAndChannel(OWNER, REPO, ReleaseChannel.STABLE))
         assertEquals(1, repository.getBundlesNeedPatchesUpdate().size)
+    }
+
+    @Test
+    fun `unavailable sources remain served but are filtered from patch extraction`() {
+        val fixture = insertSource(enabled = true)
+        val repository = BundleRepository()
+        val sourceRepository = SourceRepository()
+
+        sourceRepository.setUnavailableReason(fixture.sourceId, "451: Unavailable For Legal Reasons")
+
+        assertNotNull(repository.findById(fixture.bundleId))
+        assertNotNull(repository.findBySourceAndVersion(SOURCE_URL, VERSION, ReleaseChannel.STABLE))
+        assertTrue(repository.getBundlesNeedPatchesUpdate().isEmpty())
+
+        sourceRepository.setUnavailableReason(fixture.sourceId, null)
+
+        assertEquals(1, repository.getBundlesNeedPatchesUpdate().size)
+    }
+
+    @Test
+    fun `unavailable sources are excluded from runtime failure requeue`() {
+        val fixture = insertSource(enabled = true)
+        val repository = BundleRepository()
+        val sourceRepository = SourceRepository()
+        transaction(database) {
+            BundleTable.update({ BundleTable.id eq fixture.bundleId }) {
+                it[needPatchesUpdate] = false
+                it[patcherFailure] = "terminal"
+                it[patcherFailureFingerprint] = "old"
+            }
+        }
+        sourceRepository.setUnavailableReason(fixture.sourceId, "404: Not Found")
+
+        assertEquals(0, repository.requeuePatcherRuntimeFailures(BundleType.REVANCED_V4, "new"))
+        transaction(database) {
+            assertFalse(BundleTable.selectAll().single()[BundleTable.needPatchesUpdate])
+        }
+
+        sourceRepository.setUnavailableReason(fixture.sourceId, null)
+
+        assertEquals(1, repository.requeuePatcherRuntimeFailures(BundleType.REVANCED_V4, "new"))
+        transaction(database) {
+            assertTrue(BundleTable.selectAll().single()[BundleTable.needPatchesUpdate])
+        }
     }
 
     @Test

--- a/src/test/kotlin/me/brosssh/bundles/repositories/GitHostRateLimitRepositoryTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/repositories/GitHostRateLimitRepositoryTest.kt
@@ -1,0 +1,66 @@
+package me.brosssh.bundles.repositories
+
+import me.brosssh.bundles.db.tables.GitHostRateLimitTable
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GitHostRateLimitRepositoryTest {
+    private lateinit var repository: GitHostRateLimitRepository
+
+    @BeforeTest
+    fun setUp() {
+        val database = Database.connect(
+            url = "jdbc:h2:mem:${UUID.randomUUID()};MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+            driver = "org.h2.Driver"
+        )
+        TransactionManager.defaultDatabase = database
+        transaction(database) {
+            SchemaUtils.create(GitHostRateLimitTable)
+        }
+        repository = GitHostRateLimitRepository()
+    }
+
+    @Test
+    fun `active limit is keyed by normalized authority and credential fingerprint`() {
+        val now = OffsetDateTime.of(2026, 8, 31, 12, 0, 0, 0, ZoneOffset.UTC)
+        val deadline = now.plusMinutes(15)
+
+        repository.record("GitHub.COM", "credential-a", deadline)
+
+        assertEquals(deadline, repository.activeUntil("github.com", "credential-a", now))
+        assertNull(repository.activeUntil("github.com", "credential-b", now))
+        assertNull(repository.activeUntil("gitlab.com", "credential-a", now))
+        assertNull(repository.activeUntil("github.com", "credential-a", deadline))
+    }
+
+    @Test
+    fun `shorter observation cannot replace a later deadline`() {
+        val now = OffsetDateTime.of(2026, 8, 31, 12, 0, 0, 0, ZoneOffset.UTC)
+        repository.record("github.com", "credential", now.plusMinutes(30))
+        repository.record("github.com", "credential", now.plusMinutes(5))
+
+        assertEquals(
+            now.plusMinutes(30),
+            repository.activeUntil("github.com", "credential", now)
+        )
+    }
+
+    @Test
+    fun `successful request clears the stored limit`() {
+        val now = OffsetDateTime.of(2026, 8, 31, 12, 0, 0, 0, ZoneOffset.UTC)
+        repository.record("github.com", "credential", now.plusMinutes(15))
+
+        repository.clear("github.com", "credential")
+
+        assertNull(repository.activeUntil("github.com", "credential", now))
+    }
+}


### PR DESCRIPTION
This prevents refresh and patch workers from repeatedly attempting work that cannot currently succeed, without permanently changing bundle state.

- Record repository-level `404`, `410`, and `451` responses in `source.unavailable_reason`.
- Keep unavailable sources enabled and recheck them during later bundle refreshes. The reason is cleared only after the repository metadata and releases refresh completes successfully.
- Exclude unavailable sources from patch extraction and runtime-failure requeue while continuing to serve their cached bundles.
- Store host rate limits by normalized authority and SHA-256 credential fingerprint. Raw credentials are never persisted.
- Let each git-host client interpret its own rate-limit headers, then pause requests sharing the same host and credential until that provider's reset time. Missing or invalid reset headers use a 60-second fallback.
- Expose source unavailability reasons and terminal patcher failures through the public GraphQL role.

The rate-limit table is internal worker state and is not exposed through Hasura metadata.

Testing:

- `./gradlew test`
- Focused source availability, queue filtering, host-client failure, credential fingerprint, and rate-limit tests
- IntelliJ build and inspections