### PR TITLE
fix: improve refresh errors and bundle card feedback

### DIFF
--- a/src/main/kotlin/me/brosssh/bundles/domain/services/jobs/BaseRefreshJobService.kt
+++ b/src/main/kotlin/me/brosssh/bundles/domain/services/jobs/BaseRefreshJobService.kt
@@ -33,7 +33,7 @@ abstract class BaseRefreshJobService (
                 suspendTransaction {
                     logger.error("Error during refresh", e)
                     RefreshJobEntity[jobEntityId]
-                        .setFailed("${e.message} - ${e.cause} - ${e.stackTrace}")
+                        .setFailed(e.message ?: e.cause?.message ?: e.javaClass.simpleName)
                 }
             }
         }

--- a/src/main/kotlin/me/brosssh/bundles/domain/services/jobs/RefreshBundlesJobService.kt
+++ b/src/main/kotlin/me/brosssh/bundles/domain/services/jobs/RefreshBundlesJobService.kt
@@ -51,9 +51,8 @@ class RefreshBundlesJobService(
                         }
                     }
                 }
-            }
-            catch (e: Exception) {
-                logger.warn("Something went wrong while processing, error: ${e.cause}, ${e.message}, ${e.stackTrace}")
+            } catch (error: Exception) {
+                logger.warn("Failed to process source {}", source.url, error)
             }
 
             logger.info("Source process completed")

--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -917,22 +917,27 @@ function renderBundle(bundle, target) {
     target.appendChild(card);
 
     const copyBtn = card.querySelector(".copy-btn");
+    const copyButtonLabel = copyBtn.textContent.trim();
+    let copyFeedbackTimeout;
+    const showCopyFeedback = (text, copied = false) => {
+        clearTimeout(copyFeedbackTimeout);
+        copyBtn.textContent = text;
+        copyBtn.classList.toggle("copied", copied);
+        copyFeedbackTimeout = setTimeout(() => {
+            copyBtn.textContent = copyButtonLabel;
+            copyBtn.classList.remove("copied");
+        }, 1500);
+    };
     copyBtn.addEventListener("click", async () => {
         // The copied value must be absolute: it is pasted into the patched-app
         // manager, which resolves it from the device, not from this page.
         const url = new URL(copyBtn.dataset.url, location.origin).href;
         try {
             await navigator.clipboard.writeText(url);
-            const originalText = copyBtn.textContent;
-            copyBtn.textContent = "Copied!";
-            copyBtn.classList.add("copied");
-            setTimeout(() => {
-                copyBtn.textContent = originalText;
-                copyBtn.classList.remove("copied");
-            }, 1500);
+            showCopyFeedback("Copied!", true);
         } catch (err) {
             console.error("Failed to copy:", err);
-            copyBtn.textContent = "Failed!";
+            showCopyFeedback("Failed!");
         }
     });
 

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -218,7 +218,7 @@ h1 {
     width: 100%;
     display: grid;
     gap: 16px;
-    align-items: stretch;
+    align-items: start;
     will-change: transform;
 }
 
@@ -227,7 +227,6 @@ h1 {
 }
 
 #results .virtual-row .bundle-item {
-    height: 100%;
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary

Improves refresh failure reporting and fixes inconsistent behavior in the bundle cards.

## Changes

- Store concise refresh-job errors instead of persisting formatted stack-trace arrays.
- Log source refresh failures with the source URL and full throwable details.
- Restore the copy button label after both successful and failed copy attempts.
- Prevent overlapping copy-feedback timers.
- Keep virtualized grid cards at their natural height instead of stretching them to match other cards.

## Testing

- `.\gradlew.bat build` passed