### PR TITLE
fix: harden deployment resilience and environment isolation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,26 @@
-HOST=localhost
+# Local default. Deployments must use distinct, non-empty names (for example, development and production).
 ENV=debug
+
+# Required for deployments so Production and Development are separate Compose projects.
+# Use a unique value for each environment, for example bundles-production or bundles-development.
+# Leave empty for the default local Compose project name.
+DEPLOY_PROJECT_NAME=
+
+# Required by docker-compose.deploy.yml. Use "main" for Production and "dev" for Development.
+APP_TAG=
 
 DATABASE_HOST=localhost
 DATABASE_NAME=postgres
 DATABASE_USER=postgres
 DATABASE_PSSW=postgres
+# Required for deployments. Existing installs must use their current Postgres volume name to preserve data.
+# Deployment treats this as an external volume so Compose cannot delete it with `down -v`.
+# For new installs, create a unique volume first (for example: docker volume create bundles-production-pgdata).
+# Production and Development must use different volume names.
+DATABASE_VOLUME_NAME=
+# Host port published by docker-compose.deploy.yml; containers use Postgres internally on 5432.
+# If multiple deployments share one host, DATABASE_PORT, BACKEND_PORT, and HASURA_PORT must not overlap.
+DATABASE_PORT=5432
 
 BACKEND_PORT=8081
 BACKEND_AUTHENTICATION_SECRET=
@@ -35,6 +51,9 @@ BACKEND_PATCHER_WORKER_IDLE_SECONDS=300
 BACKEND_PATCHER_REFRESH_CONCURRENCY=4
 
 HASURA_PORT=8082
+# Optional backend-to-Hasura override. By default the backend uses http://localhost:${HASURA_PORT}.
+# docker-compose.deploy.yml overrides this with the internal Docker service URL.
+# HASURA_INTERNAL_URL=http://localhost:8082
 # Set a non-empty value. Leaving this empty causes admin authentication and
 # actions to behave inconsistently.
 HASURA_GRAPHQL_ADMIN_SECRET=

--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ The API will be available at `http://localhost:8080` by default.
 - **GraphQL Playground**: http://localhost:8080/hasura/console
 - **Web Interface**: http://localhost:8080
 
+### Deployment
+
+For Docker deployments, set `DEPLOY_ENV=deploy` and configure a separate `.env` for each environment.
+
+Required deployment values include:
+
+- `DEPLOY_PROJECT_NAME` — unique Compose project name, such as `bundles-production` or `bundles-development`
+- `ENV` - unique environment name, such as `production` or `development`
+- `APP_TAG` - `main` for Production or `dev` for Development
+- `DATABASE_VOLUME_NAME` - the PostgreSQL Docker volume used by that environment
+
+The PostgreSQL volume is treated as external and must already exist. Existing deployments must set `DATABASE_VOLUME_NAME` to their current PostgreSQL volume name to preserve existing data. For a new deployment, create the volume first, for example:
+
+```shell
+docker volume create bundles-production-pgdata
+```
+
+Production and Development must use different project names and database volumes. If both run on the same Docker host, `DATABASE_PORT`, `BACKEND_PORT`, and `HASURA_PORT` must also use different host ports.
+
+After changing deployment configuration, redeploy/recreate the Compose stack. Watchtower can update the application image, but it cannot apply Compose configuration changes.
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,8 +1,12 @@
 # For deploy
+# docker-compose.yml uses this value as the Compose project name; requiring it here
+# keeps Production and Development as separate projects when both run on one host.
+name: ${DEPLOY_PROJECT_NAME:?DEPLOY_PROJECT_NAME must be set for deployments}
+
 services:
   postgres:
     image: postgres:16
-    container_name: bundles-${ENV}-postgres
+    container_name: bundles-${ENV:?ENV must be set}-postgres
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${DATABASE_NAME}
@@ -19,11 +23,16 @@ services:
       retries: 5
 
   app:
-    image: ghcr.io/brosssh/revanced-external-bundles:${APP_TAG:-latest}
-    container_name: bundles-${ENV}-app
+    image: ghcr.io/brosssh/revanced-external-bundles:${APP_TAG:?APP_TAG must be set}
+    container_name: bundles-${ENV:?ENV must be set}-app
     restart: unless-stopped
     env_file:
       - .env
+    environment:
+      BACKEND_PORT: 8080
+      BACKEND_PATCHER_RUNTIME_DIR: /app/patcher-runtimes
+      DATABASE_HOST: postgres
+      HASURA_INTERNAL_URL: http://hasura:8080
     expose:
       - "8080"
     ports:
@@ -31,13 +40,16 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      hasura:
+        condition: service_healthy
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
+      - "com.centurylinklabs.watchtower.scope=${ENV:?ENV must be set}"
 
 
   hasura:
     image: hasura/graphql-engine:v2.31.0
-    container_name: bundles-${ENV}-hasura
+    container_name: bundles-${ENV:?ENV must be set}-hasura
     restart: unless-stopped
     expose:
       - "8080"
@@ -51,21 +63,31 @@ services:
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET}
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: user
-      HASURA_GRAPHQL_SERVER_PATH: /hasura
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:8080/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
 
   watchtower:
     image: containrrr/watchtower
-    container_name: watchtower-${ENV}
+    container_name: watchtower-${ENV:?ENV must be set}
     restart: unless-stopped
+    labels:
+      - "com.centurylinklabs.watchtower.scope=${ENV:?ENV must be set}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: >
       --label-enable
+      --scope ${ENV:?ENV must be set}
       --interval 300
 
 volumes:
   pgdata:
+    name: ${DATABASE_VOLUME_NAME:?DATABASE_VOLUME_NAME must be set}
+    external: true
 
 networks:
   default:
-    name: bundles-${ENV}-network
+    name: bundles-${ENV:?ENV must be set}-network

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -30,7 +30,6 @@ services:
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET}
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: user
-      HASURA_GRAPHQL_SERVER_PATH: /hasura
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,2 +1,4 @@
+name: ${DEPLOY_PROJECT_NAME:-revanced-external-bundles}
+
 include:
   - path: docker-compose.${DEPLOY_ENV:-local}.yml

--- a/src/main/kotlin/me/brosssh/bundles/Config.kt
+++ b/src/main/kotlin/me/brosssh/bundles/Config.kt
@@ -17,8 +17,6 @@ object Config {
     val env: String = getEnv("ENV", "production")
     val isDebug: Boolean = env.equals("debug", ignoreCase = true)
     val version: String = object {}.javaClass.`package`.implementationVersion ?: "dev"
-    val host: String = getEnv("HOST")
-    val hostUrl: URI = if (host == "localhost") URI("http://localhost:8080") else URI("https://$host")
 
     // Database
     val databaseHost: String = getEnv("DATABASE_HOST")
@@ -51,5 +49,7 @@ object Config {
     // Server
     val port: Int = getEnv("BACKEND_PORT").toInt()
 
+    private val hasuraPort: String = getEnv("HASURA_PORT", "8082")
+    val hasuraInternalUrl: URI = URI(getEnv("HASURA_INTERNAL_URL", "http://localhost:$hasuraPort"))
     val hasuraSecret: String = getEnv("HASURA_GRAPHQL_ADMIN_SECRET")
 }

--- a/src/main/kotlin/me/brosssh/bundles/db/migration/ApplyHasuraMetadata.kt
+++ b/src/main/kotlin/me/brosssh/bundles/db/migration/ApplyHasuraMetadata.kt
@@ -1,21 +1,33 @@
 package me.brosssh.bundles.db.migration
 
 import io.ktor.client.*
+import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import me.brosssh.bundles.Config
 
 suspend fun applyHasuraMetadata() {
-    with(HttpClient()) {
-        val metadataJson = javaClass
-                .classLoader
-                .getResourceAsStream("hasura/metadata.json")
-                ?.bufferedReader()
-                ?.readText()
-                ?: error("hasura/metadata.json not found on classpath")
+    val metadataJson = object {}.javaClass
+        .classLoader
+        .getResourceAsStream("hasura/metadata.json")
+        ?.bufferedReader()
+        ?.use { it.readText() }
+        ?: error("hasura/metadata.json not found on classpath")
 
-        val response = post(Config.hostUrl.resolve("/hasura/v1/metadata").toURL()) {
+    HttpClient {
+        install(HttpRequestRetry) {
+            retryOnServerErrors(maxRetries = 4)
+            retryOnException(maxRetries = 4, retryOnTimeout = true)
+            exponentialDelay()
+        }
+        // Must be installed after HttpRequestRetry for timeout exceptions to be retryable.
+        install(HttpTimeout) {
+            requestTimeoutMillis = 30_000
+            connectTimeoutMillis = 10_000
+        }
+    }.use { client ->
+        val response = client.post(Config.hasuraInternalUrl.resolve("/v1/metadata").toURL()) {
             header("X-Hasura-Admin-Secret", Config.hasuraSecret)
             contentType(ContentType.Application.Json)
             setBody("""
@@ -23,14 +35,12 @@ suspend fun applyHasuraMetadata() {
                     "type": "replace_metadata",
                     "args": $metadataJson
                 }
-            """.trimIndent()
-            )
+            """.trimIndent())
         }
 
         val body = response.bodyAsText()
-        if (response.status.value !in 200..299)
-            throw RuntimeException("Failed to apply Hasura metadata: $body. Dump again the metadata.json and try again")
-
-        close()
+        if (response.status.value !in 200..299) {
+            throw RuntimeException("Failed to apply Hasura metadata (${response.status}): $body")
+        }
     }
 }

--- a/src/main/kotlin/me/brosssh/bundles/plugins/ConfigureDatabase.kt
+++ b/src/main/kotlin/me/brosssh/bundles/plugins/ConfigureDatabase.kt
@@ -1,13 +1,69 @@
 package me.brosssh.bundles.plugins
 
 import io.ktor.server.application.*
+import kotlinx.coroutines.delay
 import me.brosssh.bundles.Config
 import me.brosssh.bundles.db.tables.*
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.sql.SQLException
 
-fun Application.configureDatabase() {
+private const val DATABASE_INIT_MAX_ATTEMPTS = 5
+private const val DATABASE_INIT_INITIAL_DELAY_MS = 1_000L
+private const val DATABASE_INIT_MAX_DELAY_MS = 8_000L
+private val RETRYABLE_DATABASE_SQL_STATES = setOf(
+    "57P01", // admin_shutdown
+    "57P02", // crash_shutdown
+    "57P03", // cannot_connect_now
+    "53300", // too_many_connections
+)
+
+internal fun Throwable.isRetryableDatabaseAvailabilityFailure(): Boolean {
+    var current: Throwable? = this
+    while (current != null) {
+        if (current is SQLException) {
+            val sqlState = current.sqlState
+            if (sqlState?.startsWith("08") == true || sqlState in RETRYABLE_DATABASE_SQL_STATES) return true
+        }
+        current = current.cause
+    }
+    return false
+}
+
+internal suspend fun retryDatabaseInitialization(
+    maxAttempts: Int = DATABASE_INIT_MAX_ATTEMPTS,
+    initialDelayMillis: Long = DATABASE_INIT_INITIAL_DELAY_MS,
+    maxDelayMillis: Long = DATABASE_INIT_MAX_DELAY_MS,
+    wait: suspend (Long) -> Unit = { delay(it) },
+    onRetry: (attempt: Int, delayMillis: Long, error: Throwable) -> Unit = { _, _, _ -> },
+    initialize: () -> Unit,
+) {
+    require(maxAttempts > 0) { "maxAttempts must be greater than zero" }
+    require(initialDelayMillis >= 0) { "initialDelayMillis must not be negative" }
+    require(maxDelayMillis >= 0) { "maxDelayMillis must not be negative" }
+
+    var retryDelayMillis = initialDelayMillis.coerceAtMost(maxDelayMillis)
+    repeat(maxAttempts) { attemptIndex ->
+        try {
+            initialize()
+            return
+        } catch (error: Exception) {
+            val attempt = attemptIndex + 1
+            if (attempt == maxAttempts || !error.isRetryableDatabaseAvailabilityFailure()) throw error
+
+            onRetry(attempt, retryDelayMillis, error)
+            wait(retryDelayMillis)
+            retryDelayMillis = if (retryDelayMillis > maxDelayMillis / 2) {
+                maxDelayMillis
+            } else {
+                retryDelayMillis * 2
+            }
+        }
+    }
+}
+
+suspend fun Application.configureDatabase() {
     val db = Database.connect(
         Config.databaseJdbcUrl,
         driver = "org.postgresql.Driver",
@@ -15,15 +71,26 @@ fun Application.configureDatabase() {
         password = Config.databasePassword
     )
 
-    transaction(db) {
-        SchemaUtils.create(BundleTable,
-            PackageTable,
-            PatchTable,
-            RefreshJobTable,
-            SourceTable,
-            SourceMetadataTable,
-            PatchPackageTable,
-            GitHostRateLimitTable
-        )
+    retryDatabaseInitialization(
+        onRetry = { attempt, retryDelayMillis, error ->
+            log.warn(
+                "Database initialization failed on attempt $attempt/$DATABASE_INIT_MAX_ATTEMPTS; " +
+                    "retrying in ${retryDelayMillis}ms",
+                error,
+            )
+        }
+    ) {
+        transaction(db) {
+            SchemaUtils.create(
+                BundleTable,
+                PackageTable,
+                PatchTable,
+                RefreshJobTable,
+                SourceTable,
+                SourceMetadataTable,
+                PatchPackageTable,
+                GitHostRateLimitTable,
+            )
+        }
     }
 }

--- a/src/test/kotlin/me/brosssh/bundles/plugins/ConfigureDatabaseTest.kt
+++ b/src/test/kotlin/me/brosssh/bundles/plugins/ConfigureDatabaseTest.kt
@@ -1,0 +1,126 @@
+package me.brosssh.bundles.plugins
+
+import kotlinx.coroutines.runBlocking
+import java.sql.SQLException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ConfigureDatabaseTest {
+    @Test
+    fun `database initialization retries connection failures with bounded backoff`() = runBlocking {
+        var attempts = 0
+        val delays = mutableListOf<Long>()
+        val retries = mutableListOf<Int>()
+
+        retryDatabaseInitialization(
+            maxAttempts = 5,
+            initialDelayMillis = 100,
+            maxDelayMillis = 150,
+            wait = { delays += it },
+            onRetry = { attempt, _, _ -> retries += attempt },
+        ) {
+            attempts++
+            if (attempts < 4) throw SQLException("connection unavailable", "08001")
+        }
+
+        assertEquals(4, attempts)
+        assertEquals(listOf(100L, 150L, 150L), delays)
+        assertEquals(listOf(1, 2, 3), retries)
+    }
+
+    @Test
+    fun `database initialization caps the initial delay`() = runBlocking {
+        val delays = mutableListOf<Long>()
+
+        assertFailsWith<SQLException> {
+            retryDatabaseInitialization(
+                maxAttempts = 2,
+                initialDelayMillis = 50,
+                maxDelayMillis = 10,
+                wait = { delays += it },
+            ) {
+                throw SQLException("connection unavailable", "08001")
+            }
+        }
+
+        assertEquals(listOf(10L), delays)
+    }
+
+    @Test
+    fun `database initialization backoff does not overflow`() = runBlocking {
+        val delays = mutableListOf<Long>()
+
+        assertFailsWith<SQLException> {
+            retryDatabaseInitialization(
+                maxAttempts = 3,
+                initialDelayMillis = Long.MAX_VALUE / 2 + 1,
+                maxDelayMillis = Long.MAX_VALUE,
+                wait = { delays += it },
+            ) {
+                throw SQLException("connection unavailable", "08001")
+            }
+        }
+
+        assertEquals(listOf(Long.MAX_VALUE / 2 + 1, Long.MAX_VALUE), delays)
+    }
+
+    @Test
+    fun `wrapped SQL connection failures are recognized`() {
+        val error = IllegalStateException(
+            "wrapped",
+            SQLException("connection lost", "08006"),
+        )
+
+        assertTrue(error.isRetryableDatabaseAvailabilityFailure())
+    }
+
+    @Test
+    fun `transient postgres availability failures are recognized`() {
+        assertTrue(SQLException("database is shutting down", "57P01").isRetryableDatabaseAvailabilityFailure())
+        assertTrue(SQLException("database crashed", "57P02").isRetryableDatabaseAvailabilityFailure())
+        assertTrue(SQLException("database is starting", "57P03").isRetryableDatabaseAvailabilityFailure())
+        assertTrue(SQLException("connection limit reached", "53300").isRetryableDatabaseAvailabilityFailure())
+    }
+
+    @Test
+    fun `database initialization does not retry non-connection failures`() = runBlocking {
+        var attempts = 0
+        val delays = mutableListOf<Long>()
+
+        assertFailsWith<SQLException> {
+            retryDatabaseInitialization(
+                wait = { delays += it },
+            ) {
+                attempts++
+                throw SQLException("constraint failure", "23505")
+            }
+        }
+
+        assertEquals(1, attempts)
+        assertTrue(delays.isEmpty())
+    }
+
+    @Test
+    fun `database initialization stops after the configured attempt limit`() = runBlocking {
+        var attempts = 0
+        val delays = mutableListOf<Long>()
+
+        assertFailsWith<SQLException> {
+            retryDatabaseInitialization(
+                maxAttempts = 3,
+                initialDelayMillis = 10,
+                maxDelayMillis = 20,
+                wait = { delays += it },
+            ) {
+                attempts++
+                throw SQLException("connection unavailable", "08001")
+            }
+        }
+
+        assertEquals(3, attempts)
+        assertEquals(listOf(10L, 20L), delays)
+    }
+}
+


### PR DESCRIPTION
## Summary

This PR improves deployment reliability and better isolates Production and Development environments.

## Changes

- Require explicit deployment values for:
  - `DEPLOY_PROJECT_NAME`
  - `ENV`
  - `APP_TAG`
  - `DATABASE_VOLUME_NAME`
- Separate Production and Development Compose projects, networks, containers, volumes, and Watchtower scopes.
- Make the PostgreSQL volume external so Compose does not own/delete it.
- Override host-oriented `.env` values with correct Docker-internal values.
- Route backend-to-Hasura requests directly through Docker networking.
- Add a Hasura health check and wait for Hasura to be healthy before starting the backend.
- Add retry/backoff handling for temporary Hasura failures.
- Add retry/backoff handling for temporary PostgreSQL connection/availability failures.
- Remove obsolete `HOST` and `HASURA_GRAPHQL_SERVER_PATH` configuration.
- Improve `.env.example` deployment documentation.
- Add tests for database retry behavior.
- Updated the `README.md` accordingly

## Validation

- 99 tests passed
- `sources.toml`: 235 sources validated
- Full JDK 21 build passed
- `git diff --check` passed
- Local, Development, and Production Compose configs validated

## Deployment note

Existing deployments must set `DATABASE_VOLUME_NAME` to their current PostgreSQL volume name to preserve existing data.

Production and Development should also use separate project names, volume names, and host ports.